### PR TITLE
Fix MIME type and download counter on file download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. This project make usage of the [Yii Versioning Strategy](https://github.com/yiisoft/yii2/blob/master/docs/internals/versions.md). In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 1.2.2
+
+### Added
+
+
+### Fixed
+
++ [#152](https://github.com/luyadev/luya-module-admin/issues/152) Added proper `Content-Type` header with MIME type when delivering download files.
+
 ## 1.2.1 (5. June 2018)
 
 ### Added

--- a/src/controllers/FileController.php
+++ b/src/controllers/FileController.php
@@ -43,6 +43,7 @@ class FileController extends \luya\web\Controller
 
                 return Yii::$app->response->sendContentAsFile($fileData->content, $model->name_original, [
                     'inline' => (bool) $model->inline_disposition,
+                    'mimeType' => $model->mime_type,
                 ]);
             }
         }

--- a/src/controllers/FileController.php
+++ b/src/controllers/FileController.php
@@ -39,10 +39,8 @@ class FileController extends \luya\web\Controller
                 }
                 
                 // update the model count stats
-                $count = $model->passthrough_file_stats + 1;
-                $model->passthrough_file_stats = $count;
-                $model->update(false);
-                
+                $model->updateCounters(['passthrough_file_stats' => 1]);
+
                 return Yii::$app->response->sendContentAsFile($fileData->content, $model->name_original, [
                     'inline' => (bool) $model->inline_disposition,
                 ]);


### PR DESCRIPTION
1. fix race condition with updating download counter.
   
    using `updateCounters()` will update the value directly in the database without the risk of running concurrently with another update.
2.  provide MIME type when delivering download files. This fixes luyadev/luya-module-cms#85.