### PR TITLE
AngularTest.php missing array in testSortRelationArrayDirective

### DIFF
--- a/src/helpers/Angular.php
+++ b/src/helpers/Angular.php
@@ -141,7 +141,7 @@ class Angular
      */
     public static function sortRelationArray($ngModel, $label, array $sourceData, array $options = [])
     {
-        return self::injector(TypesInterface::TYPE_SORT_RELATION_ARRAY, $ngModel, $label, ['sourceData' => [$sourceData]], $options);
+        return self::injector(TypesInterface::TYPE_SORT_RELATION_ARRAY, $ngModel, $label, ['sourceData' => [static::optionsArrayInput($sourceData)]], $options);
     }
         
     /**

--- a/src/helpers/Angular.php
+++ b/src/helpers/Angular.php
@@ -141,7 +141,7 @@ class Angular
      */
     public static function sortRelationArray($ngModel, $label, array $sourceData, array $options = [])
     {
-        return self::injector(TypesInterface::TYPE_SORT_RELATION_ARRAY, $ngModel, $label, ['sourceData' => $sourceData], $options);
+        return self::injector(TypesInterface::TYPE_SORT_RELATION_ARRAY, $ngModel, $label, ['sourceData' => [$sourceData]], $options);
     }
         
     /**

--- a/src/helpers/Angular.php
+++ b/src/helpers/Angular.php
@@ -141,7 +141,7 @@ class Angular
      */
     public static function sortRelationArray($ngModel, $label, array $sourceData, array $options = [])
     {
-        return self::injector(TypesInterface::TYPE_SORT_RELATION_ARRAY, $ngModel, $label, ['sourceData' => [static::optionsArrayInput($sourceData)]], $options);
+        return self::injector(TypesInterface::TYPE_SORT_RELATION_ARRAY, $ngModel, $label, ['sourceData' => static::optionsArrayInput($sourceData)], $options);
     }
         
     /**

--- a/tests/admin/helpers/AngularTest.php
+++ b/tests/admin/helpers/AngularTest.php
@@ -21,8 +21,8 @@ class AngularTest extends AdminTestCase
 
     public function testSortRelationArrayDirective()
     {
-        $this->assertSame('<zaa-sort-relation-array model="the-model" label="the-label" options=\'{"sourceData":{"foo":"bar"}}\' fieldid="the-model-zaa-sort-relation-array" fieldname="the-model"></zaa-sort-relation-array>', Angular::sortRelationArray('the-model', 'the-label', ['foo' => 'bar'])->render());
-        $this->assertSame('<zaa-sort-relation-array classAtr="value" model="the-model" label="the-label" options=\'{"sourceData":{"foo":"bar"}}\' fieldid="the-model-zaa-sort-relation-array" fieldname="the-model"></zaa-sort-relation-array>', Angular::sortRelationArray('the-model', 'the-label', ['foo' => 'bar'], ['classAtr' => 'value'])->render());
+        $this->assertSame('<zaa-sort-relation-array model="the-model" label="the-label" options=\'{"sourceData":[{"foo":"bar"}]}\' fieldid="the-model-zaa-sort-relation-array" fieldname="the-model"></zaa-sort-relation-array>', Angular::sortRelationArray('the-model', 'the-label', ['foo' => 'bar'])->render());
+        $this->assertSame('<zaa-sort-relation-array classAtr="value" model="the-model" label="the-label" options=\'{"sourceData":[{"foo":"bar"}]}\' fieldid="the-model-zaa-sort-relation-array" fieldname="the-model"></zaa-sort-relation-array>', Angular::sortRelationArray('the-model', 'the-label', ['foo' => 'bar'], ['classAtr' => 'value'])->render());
     }
 
     public function testCheckbox()

--- a/tests/admin/helpers/AngularTest.php
+++ b/tests/admin/helpers/AngularTest.php
@@ -21,8 +21,8 @@ class AngularTest extends AdminTestCase
 
     public function testSortRelationArrayDirective()
     {
-        $this->assertSame('<zaa-sort-relation-array model="the-model" label="the-label" options=\'{"sourceData":[{"foo":"bar"}]}\' fieldid="the-model-zaa-sort-relation-array" fieldname="the-model"></zaa-sort-relation-array>', Angular::sortRelationArray('the-model', 'the-label', ['foo' => 'bar'])->render());
-        $this->assertSame('<zaa-sort-relation-array classAtr="value" model="the-model" label="the-label" options=\'{"sourceData":[{"foo":"bar"}]}\' fieldid="the-model-zaa-sort-relation-array" fieldname="the-model"></zaa-sort-relation-array>', Angular::sortRelationArray('the-model', 'the-label', ['foo' => 'bar'], ['classAtr' => 'value'])->render());
+        $this->assertSame('<zaa-sort-relation-array model="the-model" label="the-label" options=\'{"sourceData":[{"label":"bar","value":"foo"}]}\' fieldid="the-model-zaa-sort-relation-array" fieldname="the-model"></zaa-sort-relation-array>', Angular::sortRelationArray('the-model', 'the-label', ['foo' => 'bar'])->render());
+        $this->assertSame('<zaa-sort-relation-array classAtr="value" model="the-model" label="the-label" options=\'{"sourceData":[{"label":"bar","value":"foo"}]}\' fieldid="the-model-zaa-sort-relation-array" fieldname="the-model"></zaa-sort-relation-array>', Angular::sortRelationArray('the-model', 'the-label', ['foo' => 'bar'], ['classAtr' => 'value'])->render());
     }
 
     public function testCheckbox()


### PR DESCRIPTION
a small typo, a defined list is missing

from directives.js
@var object $options Provides options to build the sort relation array:
     
      js
      {
      	'sourceData': [
      		{'value': 1, 'label': 'Source Entry #1'}
      		{'value': 2, 'label': 'Source Entry #2'}
      		{'value': 3, 'label': 'Source Entry #3'}
      		{'value': 4, 'label': 'Source Entry #4'}
      	]
      }
     

### What are you changing/introducing

Added array in options directive

### What is the reason for changing/introducing

javascript error

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
