### PR TITLE
correct comparaison of item value using the optionsvalue parameter 

### DIFF
--- a/src/resources/js/directives.js
+++ b/src/resources/js/directives.js
@@ -1415,7 +1415,7 @@
                 $scope.valueExistsInOptions = function(value) {
                 	var exists = false;
                 	angular.forEach($scope.options, function(item) {
-                		if (value == item.value) {
+				if (value == item[$scope.optionsvalue]) {
                 			exists = true;
                 		}
                 	});


### PR DESCRIPTION

### What are you changing/introducing
In valueExisitsInOptions functions we should use item[$scope.optionsvalue] and not item.value to compare to the given value
In `zaa.directive("zaaSelect", function() { }` 

```
-                		if (value == item.value) {
+				if (value == item[$scope.optionsvalue]) {
```

### What is the reason for changing/introducing
issue #306



### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes 
| New feature?  |  no
| Breaks BC?    |  no
| Tests pass?   | yes/no
| Fixed issues  | #306
