### PR TITLE
Fix issue 306 related to zaaSelect directive valueExisitsInOptions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ### Fixed
 
++ [#306](https://github.com/luyadev/luya-module-admin/issues/306) Fixed bug zaaSelect directive in checking if a values exists in optinos.
 + [#305](https://github.com/luyadev/luya-module-admin/issues/305) Fixed bug with module context in Api Users overview Active Window.
 + [#304](https://github.com/luyadev/luya-module-admin/issues/304) Hide tags title in file manager detail when no tags available.
 + [#303](https://github.com/luyadev/luya-module-admin/issues/303) Show message if a crud view has no entries yet.

--- a/src/resources/js/directives.js
+++ b/src/resources/js/directives.js
@@ -1406,7 +1406,7 @@ zaa.directive("zaaSelect", function() {
             $scope.valueExistsInOptions = function(value) {
                 var exists = false;
                 angular.forEach($scope.options, function(item) {
-                    if (value == item.value) {
+                    if (value == item[$scope.optionsvalue]) {
                         exists = true;
                     }
                 });


### PR DESCRIPTION
### What are you changing/introducing
In valueExisitsInOptions functions we should use item[$scope.optionsvalue] and not item.value to compare to the given value
`In zaa.directive("zaaSelect", function() { }
`
```
-                		if (value == item.value) {
+				if (value == item[$scope.optionsvalue]) {
```


### What is the reason for changing/introducing
Correct use of optionsvalue


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | n/a
| Fixed issues  | #306
