### PR TITLE
store admin language data in cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
  
 ### Added
 
++ [#333](https://github.com/luyadev/luya-module-admin/pull/333) Allow caching of language data until data is modified.
 + [#331](https://github.com/luyadev/luya-module-admin/issues/331) Add new `relation` property for SelectRelationActiveQuery.
 
 ## 2.0.3 (25. June 2019)

--- a/src/Module.php
+++ b/src/Module.php
@@ -179,7 +179,7 @@ final class Module extends \luya\admin\base\Module implements CoreModuleInterfac
     /**
      * @var boolean If enabled, the admin bootstrap process will check whether the queue job was runing within the last 30min or not. If you are not setting up any cronjob to run
      * the scheduler and you need to rely on the queue/scheulder system you enable this property which will then do a "dummy frontend user cronjob". So on every request it will
-     * check weather to run queue or not. By default this is disabled in order to prevent to have more memory and database usage. If disable setup a cronjob with `admin/queue` 
+     * check whether to run queue or not. By default this is disabled in order to prevent to have more memory and database usage. If disable setup a cronjob with `admin/queue` 
      * command using {{luya\admin\commands\QueueController}}.
      * @since 2.0.0
      * @see {{luya\admin\commands\QueueController}}

--- a/src/components/AdminLanguage.php
+++ b/src/components/AdminLanguage.php
@@ -2,6 +2,7 @@
 
 namespace luya\admin\components;
 
+use Yii;
 use yii\base\Component;
 use luya\admin\models\Lang;
 use luya\traits\CacheableTrait;

--- a/src/components/AdminLanguage.php
+++ b/src/components/AdminLanguage.php
@@ -26,6 +26,10 @@ class AdminLanguage extends Component
 {
     use CacheableTrait;
 
+    /**
+     * @var string The cache key name
+     * @since 2.0.4
+     */
     const CACHE_KEY_QUERY_ALL = 'adminLanguageCacheKey';
 
     /**
@@ -55,11 +59,11 @@ class AdminLanguage extends Component
     public function getActiveLanguage()
     {
         if ($this->_activeLanguage === null) {
-            $langShortCode = Yii::$app->composition->getKey('langShortCode');
+            $langShortCode = Yii::$app->composition->langShortCode;
             if ($langShortCode) {
-                $this->_activeLanguage = ArrayHelper::searchColumn($this->getLanuages(), 'short_code', $langShortCode);
+                $this->_activeLanguage = ArrayHelper::searchColumn($this->getLanguages(), 'short_code', $langShortCode);
             } else {
-                $this->_activeLanguage = ArrayHelper::searchColumn($this->getLanuages(), 'is_default', 1);
+                $this->_activeLanguage = ArrayHelper::searchColumn($this->getLanguages(), 'is_default', 1);
             }
         }
         
@@ -120,6 +124,12 @@ class AdminLanguage extends Component
         return isset($this->getLanguages()[$shortCode]) ? $this->getLanguages()[$shortCode] : false;
     }
 
+    /**
+     * Clear the cache data for admin language
+     *
+     * @return boolean whether clearing was successfull or not.
+     * @since 2.0.4
+     */
     public function clearCache()
     {
         return $this->deleteHasCache(self::CACHE_KEY_QUERY_ALL);

--- a/src/models/Lang.php
+++ b/src/models/Lang.php
@@ -41,6 +41,7 @@ final class Lang extends NgRestModel
             if ($this->is_default) {
                 self::updateAll(['is_default' => false]);
             }
+            Yii::$app->adminLanguage->clearCache();
         });
         
         $this->on(self::EVENT_BEFORE_UPDATE, function ($event) {
@@ -48,6 +49,7 @@ final class Lang extends NgRestModel
                 $this->markAttributeDirty('is_default');
                 self::updateAll(['is_default' => false]);
             }
+            Yii::$app->adminLanguage->clearCache();
         });
         
         $this->on(self::EVENT_BEFORE_DELETE, function ($event) {
@@ -55,6 +57,7 @@ final class Lang extends NgRestModel
                 $this->addError('is_default', Module::t('model_lang_delete_error_is_default'));
                 $event->isValid = false;
             }
+            Yii::$app->adminLanguage->clearCache();
         });
     }
     
@@ -76,6 +79,7 @@ final class Lang extends NgRestModel
             [['is_default', 'is_deleted'], 'boolean'],
             [['name'], 'string', 'max' => 255],
             [['short_code'], 'string', 'max' => 15],
+            [['short_code'], 'unique'],
         ];
     }
     

--- a/tests/admin/components/AdminLanguageTest.php
+++ b/tests/admin/components/AdminLanguageTest.php
@@ -51,7 +51,7 @@ class AdminLanguageTest extends AdminModelTestCase
         $this->app->composition->setKey(Composition::VAR_LANG_SHORT_CODE, null);
         $component = new AdminLanguage();
         $data = $component->getLanguages();
-        // This will resolve is_default = 1 because lang short code is null
+        // This will resolve is_default = 1 because lang short code is null.
         $this->assertSame(1, $component->getActiveId());
         $this->assertSame('de', $component->getActiveShortCode());
     }

--- a/tests/admin/components/AdminLanguageTest.php
+++ b/tests/admin/components/AdminLanguageTest.php
@@ -34,9 +34,6 @@ class AdminLanguageTest extends AdminModelTestCase
         ]); 
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetLanguages()
     {
         $component = new AdminLanguage();
@@ -46,5 +43,25 @@ class AdminLanguageTest extends AdminModelTestCase
         // !important: This will resolve english language because composite language is english, even when german is_default=1
         $this->assertSame(2, $component->getActiveId());
         $this->assertSame('en', $component->getActiveShortCode());
+    }
+
+    public function testGetbyShortCode()
+    {
+        $component = new AdminLanguage();
+        $this->assertSame([
+            'id' => "2",
+            'name' => 'English',
+            'short_code' => 'en',
+            'is_default' => "0",
+            'is_deleted' => "0",
+        ], $component->getLanguageByShortCode('en'));
+        $this->assertSame([
+            'id' => "1",
+            'name' => 'Deutsch',
+            'short_code' => 'de',
+            'is_default' => "1",
+            'is_deleted' => "0",
+        ], $component->getLanguageByShortCode('de'));
+        $this->assertFalse($component->clearCache()); // cache not defined... delete will faile
     }
 }

--- a/tests/admin/components/AdminLanguageTest.php
+++ b/tests/admin/components/AdminLanguageTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace luya\admin\tests\admin\components;
+
+use admintests\AdminModelTestCase;
+use luya\testsuite\fixtures\NgRestModelFixture;
+use luya\admin\models\Lang;
+use luya\admin\components\AdminLanguage;
+
+class AdminLanguageTest extends AdminModelTestCase
+{
+    protected $fixture;
+
+    public function afterSetup()
+    {
+        $this->fixture = new NgRestModelFixture([
+            'modelClass' => Lang::class,
+            'fixtureData' => [
+                1 => [
+                    'id' => 1,
+                    'name' => 'Deutsch',
+                    'short_code' => 'de',
+                    'is_default' => 1,
+                    'is_deleted' => 0,
+                ],
+                2 => [
+                    'id' => 2,
+                    'name' => 'English',
+                    'short_code' => 'en',
+                    'is_default' => 0,
+                    'is_deleted' => 0,
+                ]
+            ]
+        ]); 
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetLanguages()
+    {
+        $component = new AdminLanguage();
+        $data = $component->getLanguages();
+        $this->assertSame(2, count($data));
+
+        // !important: This will resolve english language because composite language is english, even when german is_default=1
+        $this->assertSame(2, $component->getActiveId());
+        $this->assertSame('en', $component->getActiveShortCode());
+    }
+}

--- a/tests/admin/components/AdminLanguageTest.php
+++ b/tests/admin/components/AdminLanguageTest.php
@@ -6,6 +6,7 @@ use admintests\AdminModelTestCase;
 use luya\testsuite\fixtures\NgRestModelFixture;
 use luya\admin\models\Lang;
 use luya\admin\components\AdminLanguage;
+use luya\web\Composition;
 
 class AdminLanguageTest extends AdminModelTestCase
 {
@@ -43,6 +44,16 @@ class AdminLanguageTest extends AdminModelTestCase
         // !important: This will resolve english language because composite language is english, even when german is_default=1
         $this->assertSame(2, $component->getActiveId());
         $this->assertSame('en', $component->getActiveShortCode());
+    }
+
+    public function testEmptyCompositionLangShortCode()
+    {
+        $this->app->composition->setKey(Composition::VAR_LANG_SHORT_CODE, null);
+        $component = new AdminLanguage();
+        $data = $component->getLanguages();
+        // This will resolve is_default = 1 because lang short code is null
+        $this->assertSame(1, $component->getActiveId());
+        $this->assertSame('de', $component->getActiveShortCode());
     }
 
     public function testGetbyShortCode()

--- a/tests/admin/models/LangTest.php
+++ b/tests/admin/models/LangTest.php
@@ -28,5 +28,11 @@ class LangTest extends AdminModelTestCase
 
         $this->assertTrue($model->validate());
         $this->assertTrue($model->insert());
+
+        $model->short_code = 'en';
+        $model->is_default = 0;
+        $this->assertSame(1, $model->update());
+
+        $this->assertTrue($model->delete());
     }
 }

--- a/tests/admin/models/LangTest.php
+++ b/tests/admin/models/LangTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace luya\admin\tests\admin\models;
+
+use admintests\AdminModelTestCase;
+use luya\testsuite\fixtures\NgRestModelFixture;
+use luya\admin\models\Lang;
+use luya\admin\models\NgrestLog;
+
+class LangTest extends AdminModelTestCase
+{
+    public function testEvents()
+    {
+        $fixture = new NgRestModelFixture([
+            'modelClass' => Lang::class,
+        ]);
+
+        $log = new NgRestModelFixture([
+            'modelClass' => NgrestLog::class,
+        ]);
+
+        /** @var Lang $model */
+        $model = $fixture->newModel;
+        $model->short_code = 'fr';
+        $model->name = 'Francais';
+        $model->is_default = 1;
+        $model->is_deleted = 0;
+
+        $this->assertTrue($model->validate());
+        $this->assertTrue($model->insert());
+    }
+}


### PR DESCRIPTION
+ store the admin language component data in the cache.
+ use single query to retrieve language informations from database.