### PR TITLE
I18n search fix

### DIFF
--- a/tests/admin/ngrest/base/ApiTest.php
+++ b/tests/admin/ngrest/base/ApiTest.php
@@ -4,9 +4,23 @@ namespace admintests\admin\ngrest\base;
 
 use admintests\AdminTestCase;
 use luya\admin\ngrest\base\Api;
+use luya\admin\ngrest\ConfigBuilder;
+use luya\admin\ngrest\Config;
 
 class ApiTest extends AdminTestCase
 {
+    
+    private function getConfig()
+    {
+        $config = new ConfigBuilder('model\class\name');
+
+        $config->list->field('create_var_1', 'testlabel in list')->text();
+        $config->list->field('list_var_1', 'testlabel')->textarea();
+        $config->list->field('list_var_2', 'testlabel', true)->textarea(); // This var is i18n
+
+        return $config->getConfig();
+    }
+    
     public function testWithRelations()
     {
         $rel = new TestApi('test-api', $this->app);
@@ -24,6 +38,32 @@ class ApiTest extends AdminTestCase
 
         $this->assertSame(['images', 'news.image'], $f);
     }
+
+    public function testGenerateSortAttributes()
+    {
+        $configData = $this->getConfig();
+        $ngRest = new Config(['apiEndpoint' => 'api-admin-test', 'primaryKey' => ['id']]);
+        $ngRest->setConfig($configData);
+
+        $rel = new TestApi('test-api', $this->app);
+
+        $f = $rel->generateSortAttributes($ngRest);
+
+        $this->assertTrue(array_key_exists('list_var_2', $f));
+
+        $expected = [
+            'list_var_2' => [
+                'asc' => ['(JSON_EXTRACT(`list_var_2`, "$.en"))' => SORT_ASC],
+                'desc' => ['(JSON_EXTRACT(`list_var_2`, "$.en"))' => SORT_DESC]
+            ],
+            'list_var_1',
+            'create_var_1'
+        ];
+
+
+        $this->assertSame($expected, $f);
+    }
+
 }
 
 class TestApi extends Api


### PR DESCRIPTION
### What are you changing/introducing
This is a first attempt to fix #381. 
The code automatically adds JSON_EXTRACT() function (or similar for DB others than MySQL) to the sort attributes.
The code will work only for the attributes of a table representing the current model and not for any joined tables.


### What is the reason for changing/introducing
Bug #381 


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #381 partially
