### PR TITLE
transaltion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 3.2.0
 
++ [#475](https://github.com/luyadev/luya-module-admin/pull/475) Added new option to return a none empty tag title.
+
 ## 3.1.0 (24. March 2020)
 
 > This release requires LUYA Core version 1.1 to work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 3.2.0
+
 ## 3.1.0 (24. March 2020)
 
 > This release requires LUYA Core version 1.1 to work.

--- a/src/models/Tag.php
+++ b/src/models/Tag.php
@@ -14,6 +14,7 @@ use yii\db\ActiveRecordInterface;
  * @property integer $id
  * @property string $name
  * @property string $translation
+ * @property string $translationName
  *
  * @author Basil Suter <basil@nadar.io>
  * @since 1.0.0

--- a/src/models/Tag.php
+++ b/src/models/Tag.php
@@ -110,6 +110,19 @@ final class Tag extends NgRestModel
             ['class' => DeleteTagsActiveWindow::class],
         ];
     }
+
+    /**
+     * Returns the translation, but if empty returns the name.
+     *
+     * This ensures no empty translation value is returned.
+     * 
+     * @return string
+     * @since 3.2.0
+     */
+    public function getTranslationName()
+    {
+        return empty($this->translation) ? $this->name : $this->translation;
+    }
     
     /**
      * Returns the amount of rows for the curren tag.

--- a/tests/admin/models/TagTest.php
+++ b/tests/admin/models/TagTest.php
@@ -30,7 +30,10 @@ class TagTest extends AdminModelTestCase
         $m->name = 'foo';
         $this->assertSame(true, $m->save());
 
-        $this->assertSame('goo', $m->getTranslationName());
+        $this->assertSame('foo', $m->getTranslationName());
+
+        $m->translation = 'en';
+        $this->assertSame('en', $m->getTranslationName());
 
         $uo = new NgRestModelFixture([
             'modelClass' => UserOnline::class,

--- a/tests/admin/models/TagTest.php
+++ b/tests/admin/models/TagTest.php
@@ -30,6 +30,8 @@ class TagTest extends AdminModelTestCase
         $m->name = 'foo';
         $this->assertSame(true, $m->save());
 
+        $this->assertSame('goo', $m->getTranslationName());
+
         $uo = new NgRestModelFixture([
             'modelClass' => UserOnline::class,
         ]);


### PR DESCRIPTION
Option to return either translation name or fix "name" by using `getTranslationName()` in luya\admin\models\Tag