### PR TITLE
tokenize all params

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,6 @@ jobs:
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
-          ./cc-test-reporter after-build --debug -t clover
+          ./cc-test-reporter after-build -t clover
         if: matrix.php == '7.1'
         continue-on-error: true # if is fork

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,6 @@ jobs:
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
-          ./cc-test-reporter after-build -t clover
+          ./cc-test-reporter after-build --debug -t clover
         if: matrix.php == '7.1'
         continue-on-error: true # if is fork

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 3.3.1
 
++ [#517](https://github.com/luyadev/luya-module-admin/pull/517) Fix problem with OpenApi generator URL tokens like `<identifier:[a-z0-9]+>` which are now rendered correctly as `<identifier>`
 + [#515](https://github.com/luyadev/luya-module-admin/pull/515) If {{luya\admin\ngrest\base\Api::$filterSearchModelClass}} is defined, this model will be taken into account for `filter` request param.
 + [#511](https://github.com/luyadev/luya-module-admin/issues/511) Fixed a bug where OpenApi IndexAction should return an array instead of an object.
 + [#512](https://github.com/luyadev/luya-module-admin/pull/512) Fixed a bug with multiple input types and zaaLink directives (none unique elements).

--- a/src/openapi/UrlRuleRouteParser.php
+++ b/src/openapi/UrlRuleRouteParser.php
@@ -60,7 +60,16 @@ class UrlRuleRouteParser extends BasePathParser
      */
     public function getPath() : string
     {
-        return '/'.str_replace(['<', ':\d[\d,]*>'], ['{', '}'], $this->patternRoute);
+        $route = $this->patternRoute;
+        preg_match_all('/\<(\w+)(.*?)\>/', $route, $matches);
+
+        if (isset($matches[2])) {
+            foreach ($matches[2] as $regex) {
+                $route = str_replace($regex, '', $route);
+            }
+        }
+
+        return $route;
     }
 
     /**

--- a/src/openapi/UrlRuleRouteParser.php
+++ b/src/openapi/UrlRuleRouteParser.php
@@ -69,7 +69,7 @@ class UrlRuleRouteParser extends BasePathParser
             }
         }
 
-        return $route;
+        return '/'.ltrim($route, '/');
     }
 
     /**


### PR DESCRIPTION
ensure all url params are tokenized instead of showing the regex rules.

for example `news/<token:[a-z0-9]>` is now `news/<token>`