### PR TITLE
make use of @method for yii actions in actions() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 3.3.1
 
++ [#519](https://github.com/luyadev/luya-module-admin/pull/519) Use `@method` PhpDoc to override Yii Framework defined actions in `actions()` method, otherwise those will always have the same Summary and Description Text in the OpenApi file.
 + [#517](https://github.com/luyadev/luya-module-admin/pull/517) Fix problem with OpenApi generator URL tokens like `<identifier:[a-z0-9]+>` which are now rendered correctly as `<identifier>`
 + [#515](https://github.com/luyadev/luya-module-admin/pull/515) If property `luya\admin\ngrest\base\Api::$filterSearchModelClass` is defined, the filter model will be taken into account for `filter` request param.
 + [#511](https://github.com/luyadev/luya-module-admin/issues/511) Fixed a bug where OpenApi IndexAction should return an array instead of an object.

--- a/src/Module.php
+++ b/src/Module.php
@@ -291,7 +291,7 @@ final class Module extends \luya\admin\base\Module implements CoreModuleInterfac
      * @var array An array with all apis from every module, this property is assigned by the {{luya\web\Bootstrap::run()}} method.
      * @since 1.2.2
      */
-    public $apiDefintions = [];
+    public $apiDefintions = []; // typo...
     
     /**
      * @var array This property is used by the {{luya\web\Bootstrap::run()}} method in order to set the collected asset files to assign.
@@ -304,7 +304,7 @@ final class Module extends \luya\admin\base\Module implements CoreModuleInterfac
     public $moduleMenus = [];
     
     /**
-     * @var boolean Whether a **PUBLIC** available endpoint should created returning an OpenAPI defintion for current LUYA System (including all registered modules) or not.
+     * @var boolean Whether a **PUBLIC** available endpoint should created returning an OpenAPI definition for current LUYA System (including all registered modules) or not.
      * @since 3.2.0
      */
     public $publicOpenApi = false;

--- a/src/apis/StorageController.php
+++ b/src/apis/StorageController.php
@@ -473,7 +473,7 @@ class StorageController extends RestController
             }
         }
     
-        // If the files array is empty, this is an indicator for exceeding the upload_max_filesize from php ini or a wrong upload defintion.
+        // If the files array is empty, this is an indicator for exceeding the upload_max_filesize from php ini or a wrong upload definition.
         Yii::$app->response->setStatusCode(422, 'Data Validation Failed.');
         return ['upload' => false, 'message' => Storage::getUploadErrorMessage(UPLOAD_ERR_NO_FILE), 'file' => null];
     }

--- a/src/base/Filter.php
+++ b/src/base/Filter.php
@@ -124,7 +124,7 @@ abstract class Filter extends BaseObject implements FilterInterface
     }
 
     /**
-     * Get an array with all the effect param options, based on the effect params defintion.
+     * Get an array with all the effect param options, based on the effect params definition.
      *
      * @param array $effectParams
      * @throws \luya\Exception When the vars key does not exists in the effect definition.
@@ -133,7 +133,7 @@ abstract class Filter extends BaseObject implements FilterInterface
     public function getEffectParamsList($effectParams)
     {
         if ($this->_effectParamsList === null) {
-            // see if the effect defintion contains a vars key
+            // see if the effect definition contains a vars key
             if (!array_key_exists('vars', $effectParams)) {
                 throw new Exception("Required 'vars' key not found in effect definition array.");
             }
@@ -148,10 +148,10 @@ abstract class Filter extends BaseObject implements FilterInterface
 
     /**
      * Returns a parsed effect chain for the current Filter. The method verifys if the provieded effect
-     * parameters are available in the effect defintions of luya.
+     * parameters are available in the effect definitions of luya.
      *
      * @return array Each row of the array must have "effect_id" and "effect_json_values" key.
-     * @throws \luya\Exception When effect option could be found in the effect defintions.
+     * @throws \luya\Exception When effect option could be found in the effect definitions.
      */
     public function getChain()
     {

--- a/src/commands/ProxyController.php
+++ b/src/commands/ProxyController.php
@@ -104,7 +104,7 @@ class ProxyController extends Command
     /**
      * @var string If a table option is passed only this table will be synchronised. If false by default all tables will be synced. You
      * can define multible tables ab seperating those with a comma `table1,table2,table`. In order to define only tables with start
-     * with a given prefix you can use `app_*` using asterisks symbold to define wild card starts with string defintions.
+     * with a given prefix you can use `app_*` using asterisks symbold to define wild card starts with string definitions.
      * To exclude tables you can use a `!` before the tablename e.g. `!admin_*` or multible `!admin_*,!test_*`
      */
     public $table;

--- a/src/dashboard/BasicDashboardObject.php
+++ b/src/dashboard/BasicDashboardObject.php
@@ -8,7 +8,7 @@ use luya\helpers\ArrayHelper;
 /**
  * Fast generated Dashboard Objects.
  *
- * The default object is the default class for all {{luya\admin\base\Module::$dashboardObjects}} items without a class defintion.
+ * The default object is the default class for all {{luya\admin\base\Module::$dashboardObjects}} items without a class definition.
  *
  * @author Basil Suter <basil@nadar.io>
  * @since 1.0.0

--- a/src/models/StorageFilterChain.php
+++ b/src/models/StorageFilterChain.php
@@ -201,7 +201,7 @@ final class StorageFilterChain extends ActiveRecord
     {
         $value = $this->getJsonValue($param);
         
-        // if there is no value defined, we used the default defintion from options
+        // if there is no value defined, we used the default definition from options
         if ($value === false) {
             $options = $this->effectDefinition($effect, 'options');
             $value = array_key_exists($param, $options) ? $options[$param] : false;

--- a/src/ngrest/base/Api.php
+++ b/src/ngrest/base/Api.php
@@ -123,7 +123,7 @@ class Api extends RestActiveController
     /**
      * Auto add those relations to queries.
      *
-     * This can be either an array with relations which will be passed to `index, list and view` or an array with a subdefintion in order to define
+     * This can be either an array with relations which will be passed to `index, list and view` or an array with a subdefinition in order to define
      * which relation should be us when.
      *
      * basic:
@@ -609,7 +609,7 @@ class Api extends RestActiveController
     /**
      * Generate Sort attributes
      *
-     * Generate an array of sortable attribute defintions from a ngrest config object.
+     * Generate an array of sortable attribute definitions from a ngrest config object.
      *
      * @param Config $config The Ngrest Config object
      * @return array Returns an array with sortable attributes.

--- a/src/ngrest/base/NgRestActiveQuery.php
+++ b/src/ngrest/base/NgRestActiveQuery.php
@@ -98,7 +98,7 @@ class NgRestActiveQuery extends ActiveQuery
     }
 
     /**
-     * Generate a pool where condition for a given ngRestPools() defintion.
+     * Generate a pool where condition for a given ngRestPools() definition.
      *
      * The defined pool must exists in the list of {{luya\admin\ngrest\base\NgRestModel::ngRestPools()}}. If not found
      * the where condition will not be added. If $exception is enabled an exception will be thrown when the pool identifier

--- a/src/ngrest/base/NgRestModel.php
+++ b/src/ngrest/base/NgRestModel.php
@@ -429,7 +429,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
     }
 
     /**
-     * The a single object from a primary key defintion.
+     * The a single object from a primary key definition.
      *
      * @param string $condition The condition for primary keys like `1,23` or `1`.
      * @return NgRestActiveQuery
@@ -753,7 +753,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
     }
     
     /**
-     * The NgRest config has an options property which can contain a variaty of defintions.
+     * The NgRest config has an options property which can contain a variaty of definitions.
      *
      * + saveCallback: This will trigere an angular callback after save/update of a new/existing record.
      *
@@ -795,7 +795,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
      * }
      * ```
      *
-     * You can also use an array defintion to handle booth types at the same time
+     * You can also use an array definition to handle booth types at the same time
      *
      * ```php
      * public function ngRestConfig($config)
@@ -807,9 +807,9 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
      * }
      * ```
      *
-     * @param \luya\admin\ngrest\ConfigBuilder $config The config which the defintion should be append
+     * @param \luya\admin\ngrest\ConfigBuilder $config The config which the definition should be append
      * @param string|array $assignedType This can be a string with a type or an array with multiple types
-     * @param array $fields An array with fields assign to types type based on the an `ngRestAttributeTypes` defintion.
+     * @param array $fields An array with fields assign to types type based on the an `ngRestAttributeTypes` definition.
      * @throws \yii\base\InvalidConfigException
      * @since 1.0.0
      */
@@ -877,7 +877,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
     {
         foreach ($this->ngRestScopes() as $arrayConfig) {
             if (!isset($arrayConfig[0]) && !isset($arrayConfig[1])) {
-                throw new InvalidConfigException("Invalid ngRestScope defintion. Definition must contain an array with two elements: `['create', []]`");
+                throw new InvalidConfigException("Invalid ngRestScope definition. Definition must contain an array with two elements: `['create', []]`");
             }
             
             $scope = $arrayConfig[0];
@@ -970,7 +970,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
     }
 
     /**
-     * Get the NgRest Relation defintion object.
+     * Get the NgRest Relation definition object.
      *
      * @param integer $index
      * @return NgRestRelationInterface

--- a/src/ngrest/base/NgRestRelation.php
+++ b/src/ngrest/base/NgRestRelation.php
@@ -9,7 +9,7 @@ use yii\db\ActiveQuery;
 use yii\base\InvalidConfigException;
 
 /**
- * NgRest Relation Defintion.
+ * NgRest Relation definition.
  *
  * An NgRest Relation defined which is used by {{luya\admin\ngrest\base\NgRestModel::ngRestRelations()}} array.
  *

--- a/src/ngrest/base/NgRestRelationInterface.php
+++ b/src/ngrest/base/NgRestRelationInterface.php
@@ -5,7 +5,7 @@ namespace luya\admin\ngrest\base;
 /**
  * NgRest Relation Interface.
  *
- * Each relation defintion must be an instance of this class.
+ * Each relation definition must be an instance of this class.
  *
  * @author Basil Suter <basil@nadar.io>
  */

--- a/src/ngrest/base/Plugin.php
+++ b/src/ngrest/base/Plugin.php
@@ -31,7 +31,7 @@ use luya\admin\helpers\Angular;
  * + onExpandFind: Equals to onFind but only for the view api of the model, which means the data which is used for edit.
  * + onSave: Before Update / Create of the new data set.
  *
- * @property string|array $sortField Sort field defintion (since 2.0.0)
+ * @property string|array $sortField Sort field definition (since 2.0.0)
  *
  * @author Basil Suter <basil@nadar.io>
  * @since 1.0.0
@@ -182,7 +182,7 @@ abstract class Plugin extends Component implements TypesInterface
     /**
      * Setter method for sortField
      *
-     * @param string|array $field A sort field definition, this can be either a string `firstname` or an array with a defintion or multiple defintions
+     * @param string|array $field A sort field definition, this can be either a string `firstname` or an array with a definition or multiple definitions
      *
      * ```php
      * 'sortField' => [
@@ -243,7 +243,7 @@ abstract class Plugin extends Component implements TypesInterface
     }
 
     /**
-     * Getter method for a sortField defintion.
+     * Getter method for a sortField definition.
      *
      * If no sortField definition has been set, the plugin attribute name is used.
      *

--- a/src/ngrest/plugins/CheckboxRelationActiveQuery.php
+++ b/src/ngrest/plugins/CheckboxRelationActiveQuery.php
@@ -9,7 +9,7 @@ use yii\base\InvalidConfigException;
 /**
  * Checkbox relation based on an Active Query.
  *
- * This plugin uses the active linking abilities of the yii relation defintions (hasMany, viaTable, hasOne).
+ * This plugin uses the active linking abilities of the yii relation definitions (hasMany, viaTable, hasOne).
  *
  * Example implementation:
  *

--- a/src/ngrest/plugins/SelectModel.php
+++ b/src/ngrest/plugins/SelectModel.php
@@ -153,10 +153,10 @@ class SelectModel extends Select
             $this->labelField = $model->attributes();
         }
         
-        $defintion = (array) $this->labelField;
+        $definition = (array) $this->labelField;
         
         $values = [];
-        foreach ($defintion as $field) {
+        foreach ($definition as $field) {
             $data = $model->i18nAttributeValue($field);
             
             if (is_array($data)) {

--- a/src/ngrest/plugins/SelectRelationActiveQuery.php
+++ b/src/ngrest/plugins/SelectRelationActiveQuery.php
@@ -32,7 +32,7 @@ use yii\base\InvalidConfigException;
  * }
  * ```
  *
- * > Important: Keep in mind that the relation class which is used inside the query defintion for `Client` must be an NgRest CRUD model with controller and API!
+ * > Important: Keep in mind that the relation class which is used inside the query definition for `Client` must be an NgRest CRUD model with controller and API!
  *
  * If you have composite keys or large to with big list, in order to preserve the assign on list find you can enable `asyncList`.
  *

--- a/src/ngrest/render/RenderCrud.php
+++ b/src/ngrest/render/RenderCrud.php
@@ -667,7 +667,7 @@ class RenderCrud extends Render implements ViewContextInterface, RenderCrudInter
     /**
      * Generate an array for every group withing the given pointer elemenets.
      *
-     * If there is no group defintion, it will generate a "default" group.
+     * If there is no group definition, it will generate a "default" group.
      *
      * @param [type] $pointerElements
      * @return array

--- a/src/ngrest/render/RenderCrudInterface.php
+++ b/src/ngrest/render/RenderCrudInterface.php
@@ -72,14 +72,14 @@ interface RenderCrudInterface
     public function getModelSelection();
     
     /**
-     * Optional defintions for settings button. Those definitions are made in the ngrest crud controller.
+     * Optional definitions for settings button. Those definitions are made in the ngrest crud controller.
      *
      * @param array $buttons
      */
     public function setSettingButtonDefinitions(array $buttons);
     
     /**
-     * Get an array with additionals button defintions.
+     * Get an array with additionals button definitions.
      *
      * @return array
      */

--- a/src/openapi/BasePathParser.php
+++ b/src/openapi/BasePathParser.php
@@ -21,7 +21,7 @@ abstract class BasePathParser
     /**
      * Return a PathItem.
      *
-     * A PathItem represents a path within the openapi defintion. A path (or maybe also named as endpoint/route) can have multiple verbs.
+     * A PathItem represents a path within the openapi definition. A path (or maybe also named as endpoint/route) can have multiple verbs.
      * Like post, get, put
      *
      * @return PathItem

--- a/src/openapi/UrlRuleRouteParser.php
+++ b/src/openapi/UrlRuleRouteParser.php
@@ -231,10 +231,21 @@ class UrlRuleRouteParser extends BasePathParser
             }
         }
 
+        // check if an @method phpdoc is available for the current controller:
+        $phpDocMethod = $this->controllerSpecs->getPhpDocParser()->getMethod($actionSpecs->getActionName());
+
+        if ($phpDocMethod) {
+            $summary = $phpDocMethod->getNormalizedMethodName();
+            $description = $phpDocMethod->getDescription();
+        } else {
+            $summary = $actionSpecs->getSummary();
+            $description = $actionSpecs->getDescription();
+        }
+
         return new Operation(array_filter([
             'tags' => [$this->normalizeTag($this->endpointName)],
-            'summary' => $actionSpecs->getSummary(),
-            'description' => $actionSpecs->getDescription(),
+            'summary' => $summary,
+            'description' => $description,
             'operationId' => $this->generateOperationId($verbName),
             'parameters' => $params,
             'responses' => new Responses($actionSpecs->getResponses()),

--- a/src/openapi/phpdoc/PhpDocMethod.php
+++ b/src/openapi/phpdoc/PhpDocMethod.php
@@ -11,7 +11,7 @@ use luya\helpers\StringHelper;
  * The @method phpdoc describer.
  * 
  * @author Basil <git@nadar.io>
- * @since 3.x
+ * @since 3.3.1
  */
 class PhpDocMethod
 {
@@ -61,6 +61,13 @@ class PhpDocMethod
         return Inflector::camel2words($methodName);
     }
 
+    /**
+     * Method Param Description
+     *
+     * Returns the defintion of the action inside the () params.
+     * 
+     * @return string
+     */
     public function getMethodParams()
     {
         return isset($this->definition[3]) ? trim($this->definition[3]) : false;

--- a/src/openapi/phpdoc/PhpDocMethod.php
+++ b/src/openapi/phpdoc/PhpDocMethod.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace luya\admin\openapi\phpdoc;
+
+use luya\helpers\Inflector;
+use luya\helpers\StringHelper;
+
+/**
+ * Php DOc Method
+ * 
+ * The @method phpdoc describer.
+ * 
+ * @author Basil <git@nadar.io>
+ * @since 3.x
+ */
+class PhpDocMethod
+{
+    protected $phpDocParser;
+
+    protected $definition;
+
+    public function __construct(PhpDocParser $phpDocParser, array $definition)
+    {
+        $this->phpDocParser = $phpDocParser;
+        $this->definition = $definition;
+    }
+
+    /**
+     * PhpDocType
+     *
+     * @return PhpDocType
+     */
+    public function getReturnType()
+    {
+        return new PhpDocType($this->phpDocParser, isset($this->definition[1]) ? $this->definition[1] : null);
+    }
+    
+    /**
+     * Method Name
+     * 
+     * Returns only the method name without arguments, for example actionView($id) should return actionView
+     *
+     * @return string
+     */
+    public function getMethodName()
+    {
+        return isset($this->definition[2]) ? trim($this->definition[2]) : false;
+    }
+
+    /**
+     * Returns a readable name for an action
+     * 
+     * For example the action is actionFooBar it will return `Foo Bar`.
+     *
+     * @return void
+     */
+    public function getNormalizedMethodName()
+    {
+        $methodName = StringHelper::replaceFirst('action', '', $this->getMethodName());
+
+        return Inflector::camel2words($methodName);
+    }
+
+    public function getMethodParams()
+    {
+        return isset($this->definition[3]) ? trim($this->definition[3]) : false;
+    }
+
+    /**
+     * Description.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return isset($this->definition[4]) ? $this->definition[4] : '';
+    }
+}

--- a/src/openapi/phpdoc/PhpDocMethod.php
+++ b/src/openapi/phpdoc/PhpDocMethod.php
@@ -15,10 +15,22 @@ use luya\helpers\StringHelper;
  */
 class PhpDocMethod
 {
+    /**
+     * @var PhpDocParser
+     */
     protected $phpDocParser;
 
+    /**
+     * @var array
+     */
     protected $definition;
 
+    /**
+     * Constructor
+     *
+     * @param PhpDocParser $phpDocParser
+     * @param array $definition
+     */
     public function __construct(PhpDocParser $phpDocParser, array $definition)
     {
         $this->phpDocParser = $phpDocParser;
@@ -26,7 +38,9 @@ class PhpDocMethod
     }
 
     /**
-     * PhpDocType
+     * Type
+     * 
+     * Returns a Type definition.
      *
      * @return PhpDocType
      */
@@ -64,7 +78,7 @@ class PhpDocMethod
     /**
      * Method Param Description
      *
-     * Returns the defintion of the action inside the () params.
+     * Returns the definition of the action inside the () params.
      * 
      * @return string
      */

--- a/src/openapi/phpdoc/PhpDocParser.php
+++ b/src/openapi/phpdoc/PhpDocParser.php
@@ -76,17 +76,30 @@ class PhpDocParser
         return $rows;
     }
 
+    /**
+     * Returns all PhpDoc @method definitions
+     *
+     * @return PhpDocMethod[] An array where the key is the methodName like `actionIndex`
+     * @since 3.3.1
+     */
     public function getMethods()
     {
         $methods = [];
         foreach ($this->rows['method'] as $method) {
-            $o = new PhpDocMethod($this, $method);
-            $methods[$o->getMethodName()] = $o;
+            $phpDocMethod = new PhpDocMethod($this, $method);
+            $methods[$phpDocMethod->getMethodName()] = $phpDocMethod;
         }
 
         return $methods;
     }
 
+    /**
+     * Get a PhpDoc @method definition by its name
+     *
+     * @param string $name The name of the action which is defined, for example `actionIndex`
+     * @return PhpDocMethod
+     * @since 3.3.1
+     */
     public function getMethod($name)
     {
         return isset($this->getMethods()[$name]) ? $this->getMethods()[$name] : false;

--- a/src/openapi/phpdoc/PhpDocType.php
+++ b/src/openapi/phpdoc/PhpDocType.php
@@ -128,7 +128,7 @@ class PhpDocType
             return $absoluteClassName;
         }
 
-        // Find alias defintion `XYZ as ABC`
+        // Find alias definition `XYZ as ABC`
         $ensureClassName = $this->phpDocParser->ensureClassName($className);
         if ($ensureClassName && class_exists($ensureClassName)) {
             return $ensureClassName;

--- a/src/openapi/specs/ControllerActionSpecs.php
+++ b/src/openapi/specs/ControllerActionSpecs.php
@@ -57,6 +57,11 @@ class ControllerActionSpecs extends BaseSpecs
         return $this->_actionObject;
     }
 
+    public function getActionName()
+    {
+        return 'action'.Inflector::id2camel($this->actioName);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -65,7 +70,7 @@ class ControllerActionSpecs extends BaseSpecs
         if ($this->getActionObject() instanceof InlineAction) {
             // read data from: actionMethodName()
             $reflector = new ReflectionClass(get_class($this->getControllerObject()));
-            return $reflector->getMethod('action'.Inflector::id2camel($this->actioName));
+            return $reflector->getMethod($this->getActionName());
         }
 
         return new ReflectionClass(get_class($this->getActionObject()));

--- a/src/openapi/specs/ControllerActionSpecs.php
+++ b/src/openapi/specs/ControllerActionSpecs.php
@@ -57,6 +57,14 @@ class ControllerActionSpecs extends BaseSpecs
         return $this->_actionObject;
     }
 
+    /**
+     * Returns a full qualified action name.
+     * 
+     * This is mainly used for {{yii\base\Controller::actions()}} definition.
+     *
+     * @return string Assuming the actionName is `update-row` then it will return `actionUpdateRow`.
+     * @since 3.3.1
+     */
     public function getActionName()
     {
         return 'action'.Inflector::id2camel($this->actioName);

--- a/src/resources/js/controllers.js
+++ b/src/resources/js/controllers.js
@@ -310,9 +310,9 @@
 			if ($scope.config.relationCall) {
 				var relations = $scope.$parent.$parent.config.relations;
 				var definition = relations[parseInt($scope.config.relationCall.arrayIndex)];
-				var linkDefintion = definition.relationLink;
+				var linkdefinition = definition.relationLink;
 
-				if (linkDefintion !== null && linkDefintion.hasOwnProperty(field)) {
+				if (linkdefinition !== null && linkdefinition.hasOwnProperty(field)) {
 					return parseInt($scope.config.relationCall.id);
 				}
 			}

--- a/src/resources/js/directives.js
+++ b/src/resources/js/directives.js
@@ -1501,7 +1501,7 @@ zaa.directive("zaaRadio", function () {
     *
     * If an initvalue is provided, you can not reset the model to null.
     *
-    * Options value defintion:
+    * Options value definition:
     *
     * ```js
     * options=[{"value":123,"label":123-Label}, {"value":abc,"label":ABC-Label}]

--- a/src/storage/QueryTrait.php
+++ b/src/storage/QueryTrait.php
@@ -253,7 +253,7 @@ trait QueryTrait
      *
      * This will only appaend the first condition where id is bigger then 1 and ignore the second one
      *
-     * @param array $args The where defintion can be either an key-value pairing or a condition representen as array.
+     * @param array $args The where definition can be either an key-value pairing or a condition representen as array.
      * @return QueryTrait
      * @throws Exception
      */
@@ -281,7 +281,7 @@ trait QueryTrait
      *
      * See {{luya\admin\storage\QueryTrait::where()}}
      *
-     * @param array $args The where defintion can be either an key-value pairing or a condition representen as array.
+     * @param array $args The where definition can be either an key-value pairing or a condition representen as array.
      * @return \luya\admin\storage\QueryTrait
      */
     public function andWhere(array $args)

--- a/tests/admin/ngrest/render/RenderCrudTest.php
+++ b/tests/admin/ngrest/render/RenderCrudTest.php
@@ -22,7 +22,7 @@ class RenderCrudTest extends AdminModelTestCase
         return new RenderCrud();
     }
     
-    public function testSettingButtonDefintion()
+    public function testSettingButtondefinition()
     {
         $crud = $this->getCrud();
         $crud->setSettingButtonDefinitions([

--- a/tests/admin/openapi/GeneratorTest.php
+++ b/tests/admin/openapi/GeneratorTest.php
@@ -17,7 +17,6 @@ use luya\admin\models\StorageImage;
 use luya\admin\openapi\Generator;
 use luya\testsuite\fixtures\NgRestModelFixture;
 use luya\testsuite\traits\DatabaseTableTrait;
-use luya\web\Bootstrap;
 use luya\web\UrlManager;
 
 class GeneratorTest extends AdminModelTestCase

--- a/tests/admin/openapi/UrlRulePhpDocTest.php
+++ b/tests/admin/openapi/UrlRulePhpDocTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace luya\admin\tests\admin\openapi;
+
+use admintests\AdminModelTestCase;
+use cebe\openapi\spec\PathItem;
+use luya\admin\openapi\Generator;
+use luya\admin\openapi\OpenApiGenerator;
+use luya\admin\tests\data\controllers\OpenApiController;
+use luya\testsuite\traits\DatabaseTableTrait;
+use luya\web\UrlManager;
+use yii\rest\UrlRule;
+
+class UrlRulePhpDocTest extends AdminModelTestCase
+{
+    use DatabaseTableTrait;
+
+    public function testUrlRuleWithMethodPhpDoc()
+    {
+        $this->createAdminLangFixture();
+
+        $urlManager = new UrlManager();
+        $urlManager->addRules([
+            [
+                'class' => UrlRule::class,
+                'controller' => 'open-api',
+            ]
+        ]);
+
+        $this->app->controllerMap = [
+            'open-api' => OpenApiController::class,
+        ];
+
+        $generator = new Generator($urlManager);
+        
+
+        $paths = $generator->getPaths();
+
+        $this->assertArrayHasKey('/open-apis', $paths);
+
+        /** @var PathItem $path */
+        $path = $paths['/open-apis'];
+
+        $this->assertSame('Controller Description', $path->description);
+        $this->assertSame('Controller Summary', $path->summary);
+
+        $this->assertSame('Index', $path->get->summary);
+        $this->assertSame('Return the data models ..', $path->get->description);
+
+        $openapi = new OpenApiGenerator($generator);
+        $json = $openapi->create()->getSerializableData();
+
+        //var_dump($json);
+    }
+}

--- a/tests/admin/openapi/UrlRulePhpDocTest.php
+++ b/tests/admin/openapi/UrlRulePhpDocTest.php
@@ -24,6 +24,9 @@ class UrlRulePhpDocTest extends AdminModelTestCase
             [
                 'class' => UrlRule::class,
                 'controller' => 'open-api',
+                'extraPatterns' => [
+                    'POST save-user' => 'save-user',
+                ]
             ]
         ]);
 
@@ -43,13 +46,27 @@ class UrlRulePhpDocTest extends AdminModelTestCase
 
         $this->assertSame('Controller Description', $path->description);
         $this->assertSame('Controller Summary', $path->summary);
-
         $this->assertSame('Index', $path->get->summary);
         $this->assertSame('Return the data models ..', $path->get->description);
 
-        $openapi = new OpenApiGenerator($generator);
-        $json = $openapi->create()->getSerializableData();
+        /** @var PathItem $save */
+        $save = $paths['/open-apis/save-user'];
 
-        //var_dump($json);
+        $this->assertSame('Controller Description', $save->description);
+        $this->assertSame('Controller Summary', $save->summary);
+        $this->assertSame('Post information', $save->post->summary);
+        $this->assertSame('Description of Save Action', $save->post->description);
+
+        $username = $save->post->requestBody->content['application/json']->schema->properties['username'];
+        $this->assertSame('username', $username->title);
+        $this->assertSame('string', $username->type);
+
+        $status = $save->post->requestBody->content['application/json']->schema->properties['status'];
+        $this->assertSame('status', $status->title);
+        $this->assertSame('integer', $status->type);
+       
+        $openapi = new OpenApiGenerator($generator);
+        
+        $this->assertNotEmpty($openapi->create()->getSerializableData());
     }
 }

--- a/tests/data/controllers/OpenApiController.php
+++ b/tests/data/controllers/OpenApiController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace luya\admin\tests\data\controllers;
+
+use luya\admin\models\Lang;
+use yii\rest\Controller;
+use yii\rest\IndexAction;
+
+/**
+ * Controller Summary
+ * 
+ * Controller Description
+ * @method Lang[] actionIndex() Return the data models ..
+ */
+class OpenApiController extends Controller
+{
+    public function actions()
+    {
+        return [
+            'index' => [
+                'class' => IndexAction::class,
+                'modelClass' => Lang::class,
+            ],
+        ];
+    }
+}

--- a/tests/data/controllers/OpenApiController.php
+++ b/tests/data/controllers/OpenApiController.php
@@ -23,4 +23,16 @@ class OpenApiController extends Controller
             ],
         ];
     }
+
+    /**
+     * Post information
+     * 
+     * Description of Save Action
+     * @uses string $username
+     * @uses int status
+     */
+    public function actionSaveUser()
+    {
+        //
+    }
 }


### PR DESCRIPTION
When working with Yii Framework `actions()` definition its hard to override the default title and description which is generic.

Therefore the `@method \app\models\User[] actionIndex() The index action will return all users` can be used. This helps improve the Controllers Code and also generates more meaningful documentations.