### PR TITLE
Use raw name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 3.4.1
+
++ [#533](https://github.com/luyadev/luya-module-admin/pull/533) Fixed a bug where OpenApi property relations won't expand.
+
 ## 3.4.0 (21. July 2020)
 
 + [#530](https://github.com/luyadev/luya-module-admin/pull/530) Attach query behaviors in `luya\admin\ngrest\base\NgRestModel::find`.

--- a/src/openapi/phpdoc/PhpDocType.php
+++ b/src/openapi/phpdoc/PhpDocType.php
@@ -37,7 +37,7 @@ class PhpDocType
 
     public function getIsScalar()
     {
-        return in_array($this->getNoramlizeName(), [
+        return in_array($this->rawName), [
             'bool',
             'boolean',
             'string',

--- a/src/openapi/phpdoc/PhpDocType.php
+++ b/src/openapi/phpdoc/PhpDocType.php
@@ -69,7 +69,7 @@ class PhpDocType
 
     public function getIsArray()
     {
-        return StringHelper::contains('[]', $this->name) || in_array($this->name, [
+        return StringHelper::contains('[]', $this->rawName) || in_array($this->name, [
             'array',
             'iterable',
         ]);

--- a/src/openapi/phpdoc/PhpDocType.php
+++ b/src/openapi/phpdoc/PhpDocType.php
@@ -37,7 +37,7 @@ class PhpDocType
 
     public function getIsScalar()
     {
-        return in_array($this->rawName), [
+        return in_array($this->rawName, [
             'bool',
             'boolean',
             'string',


### PR DESCRIPTION
If not the raw name is used the object context informations wont work as normalized values only return default values like string, integer even when the resources is a class name
