### PR TITLE
disable auth for options when cors is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 > This requires LUYA core 1.7
 
 + [#533](https://github.com/luyadev/luya-module-admin/pull/553) Use new `Yii::$app->getAdminModulesMenus()`, `Yii::$app->getAdminModulesJsTranslationMessages()` and `Yii::$app->getAdminModulesAssets()` method in order to retrieve module data. This fixes a bug with admin modules which does not have an `admin` in the module name f.e. `'usertoken' => 'luya\admin\usertoken\Module'`.
++ [#561](https://github.com/luyadev/luya-module-admin/pull/561) Disable LUYA admin auth checks when cors is enabled and request method is options.
 
 ## 3.5.2 (26. August 2020)
 

--- a/src/traits/AdminRestBehaviorTrait.php
+++ b/src/traits/AdminRestBehaviorTrait.php
@@ -89,9 +89,9 @@ trait AdminRestBehaviorTrait
     /**
      * Wether the given action id does not required authentication or not.
      * 
-     * > Since XX this will also return true when cors is enabled and the request method is OPTIONS. As the `optional` actions list
-     * is passed to the authenticator behavior, this is the place where authentication happens and is done anyhow before `isActionAuthOptional()
-     * is used in `beforeAction()` checks.
+     * > {@since 3.6.0} this will also return true when cors is enabled and the request method is OPTIONS. As the `optional` actions list
+     * > is passed to the authenticator behavior, this is the place where authentication happens and is done anyhow before `isActionAuthOptional()
+     * > is used in `beforeAction()` checks.
      *
      * @param string $actionId
      * @return boolean

--- a/src/traits/AdminRestBehaviorTrait.php
+++ b/src/traits/AdminRestBehaviorTrait.php
@@ -88,6 +88,10 @@ trait AdminRestBehaviorTrait
 
     /**
      * Wether the given action id does not required authentication or not.
+     * 
+     * > Since XX this will also return true when cors is enabled and the request method is OPTIONS. As the `optional` actions list
+     * is passed to the authenticator behavior, this is the place where authentication happens and is done anyhow before `isActionAuthOptional()
+     * is used in `beforeAction()` checks.
      *
      * @param string $actionId
      * @return boolean
@@ -95,6 +99,10 @@ trait AdminRestBehaviorTrait
      */
     public function isActionAuthOptional($actionId)
     {
+        if ($this->enableCors && Yii::$app->request->isOptions) {
+            return true;
+        }
+
         return in_array($actionId, $this->authOptional);
     }
     

--- a/tests/admin/base/RestActiveControllerTest.php
+++ b/tests/admin/base/RestActiveControllerTest.php
@@ -2,12 +2,19 @@
 
 namespace luya\admin\tests\admin\base;
 
-use admintests\AdminTestCase;
+use admintests\AdminModelTestCase;
 use luya\admin\base\RestActiveController;
 
-class RestActiveControllerTest extends AdminTestCase
+class RestActiveControllerTest extends AdminModelTestCase
 {
     public function testCheckEndpointAccess()
     {
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        $this->createAdminLangFixture();
+        $sub = new class('id', $this->app) extends RestActiveController {
+            public $modelClass = 'User';
+        };
+        $sub->enableCors = true;
+        $this->assertTrue($sub->isActionAuthOptional('unknown'));
     }
 }


### PR DESCRIPTION
Disable auth check for options request when cors is enabled. This is not a security problem since the authenticator is running BEFORE those checks and is therefore commonly only allowed when the actionOptions is requested.