### PR TITLE
do not mark attribute dirty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 > This requires LUYA core 1.7
 
++ [#567](https://github.com/luyadev/luya-module-admin/pull/567) Do not marke i18n values as dirty when they are populated from the database, store the original json value from the database in a new `setI18nOldValue()` method instead.
 + [#533](https://github.com/luyadev/luya-module-admin/pull/553) Use new `Yii::$app->getAdminModulesMenus()`, `Yii::$app->getAdminModulesJsTranslationMessages()` and `Yii::$app->getAdminModulesAssets()` method in order to retrieve module data. This fixes a bug with admin modules which does not have an `admin` in the module name f.e. `'usertoken' => 'luya\admin\usertoken\Module'`.
 + [#561](https://github.com/luyadev/luya-module-admin/pull/561) Disable LUYA admin auth checks when cors is enabled and request method is options.
 + [#562](https://github.com/luyadev/luya-module-admin/pull/562) New `luya\admin\validators\I18nRequiredValidator` validator in order to validate i18n attributes an its content. The validator checks if all language short codes exist and if the corresponding value is empty.

--- a/src/ngrest/base/NgRestModel.php
+++ b/src/ngrest/base/NgRestModel.php
@@ -213,6 +213,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
      * @param string $value A json with the values f.e. `{"de":"foobar","en":"foobaz"}`
      * @since 3.6.0
      * @see {{getI18nOldValue()}}
+     * @see https://github.com/luyadev/luya-module-admin/pull/567
      */
     public function setI18nOldValue($attributeName, $value)
     {
@@ -226,6 +227,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
      * @return string The json value from either the old value setter array or the active record getOldAttribute() method.
      * @since 3.6.0
      * @see {{setI18nOldValue()}}
+     * @see https://github.com/luyadev/luya-module-admin/pull/567
      */
     public function getI18nOldValue($attributeName)
     {

--- a/src/ngrest/base/NgRestModel.php
+++ b/src/ngrest/base/NgRestModel.php
@@ -202,11 +202,31 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
 
     private $_i18nOldValues = [];
 
+    /**
+     * Set the old json value from a i18n database value.
+     * 
+     * This method is used when the ngrest plugins are overiding the values from the database. Therefore the original database
+     * values can be stored here in order to retrieve those informations in later stage. f.e. when accessing language values for another
+     * language the current application language
+     *
+     * @param string $attributeName The attribute name associated with the json value
+     * @param string $value A json with the values f.e. `{"de":"foobar","en":"foobaz"}`
+     * @since 3.6.0
+     * @see {{getI18nOldValue()}}
+     */
     public function setI18nOldValue($attributeName, $value)
     {
         $this->_i18nOldValues[$attributeName] = $value;
     }
 
+    /**
+     * Get the old/original i18n value from the database.
+     *
+     * @param string $attributeName
+     * @return string The json value from either the old value setter array or the active record getOldAttribute() method.
+     * @since 3.6.0
+     * @see {{setI18nOldValue()}}
+     */
     public function getI18nOldValue($attributeName)
     {
         return array_key_exists($attributeName, $this->_i18nOldValues) ? $this->_i18nOldValues[$attributeName] : $this->getOldAttribute($attributeName);

--- a/src/ngrest/base/NgRestModel.php
+++ b/src/ngrest/base/NgRestModel.php
@@ -200,6 +200,18 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
         return in_array($attributeName, $this->i18n);
     }
 
+    private $_i18nOldValues = [];
+
+    public function setI18nOldValue($attributeName, $value)
+    {
+        $this->_i18nOldValues[$attributeName] = $value;
+    }
+
+    public function getI18nOldValue($attributeName)
+    {
+        return array_key_exists($attributeName, $this->_i18nOldValues) ? $this->_i18nOldValues[$attributeName] : $this->getOldAttribute($attributeName);
+    }
+
     /**
      * Returns the value for an i18n field before it was casted to the output for the current active language if empty.
      *
@@ -222,7 +234,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
 
         if (empty($value) && $this->isI18n($attributeName)) {
             // get the decoded value from old attribute value.
-            $array = I18n::decode($this->getOldAttribute($attributeName));
+            $array = I18n::decode($this->getI18nOldValue($attributeName));
 
             if ($preferredLanguage && isset($array[$preferredLanguage]) && !empty($array[$preferredLanguage])) {
                 return $this->runI18nContextOnFindPlugin($attributeName, $array[$preferredLanguage]);
@@ -284,7 +296,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
     public function i18nAttributeLanguageValue($attributeName, $language, $raw = false)
     {
         // get the decoded value from old attribute value.
-        $array = I18n::decode($this->getOldAttribute($attributeName));
+        $array = I18n::decode($this->getI18nOldValue($attributeName));
 
         // if language is available in the array
         if (isset($array[$language])) {

--- a/src/ngrest/base/Plugin.php
+++ b/src/ngrest/base/Plugin.php
@@ -704,13 +704,14 @@ abstract class Plugin extends Component implements TypesInterface
     {
         if ($this->isAttributeWriteable($event) && $this->onBeforeFind($event)) {
             if ($this->i18n) {
-
+                $oldValue = $event->sender->getAttribute($this->name);
+                $event->sender->setI18nOldValue($this->name, $oldValue);
                 // get the new array value from an i18n json attribute
-                $value = I18n::decodeFindActive($event->sender->getAttribute($this->name), $this->i18nEmptyValue);
+                $value = I18n::decodeFindActive($oldValue, $this->i18nEmptyValue);
                 // set the new attribute value
                 $event->sender->setAttribute($this->name, $value);
                 // override the old attribute value in order to ensure this attribute is not marked as dirty
-                // see: 
+                // see: https://github.com/luyadev/luya-module-admin/pull/567
                 $event->sender->setOldAttribute($this->name, $value);
             }
             

--- a/src/ngrest/base/Plugin.php
+++ b/src/ngrest/base/Plugin.php
@@ -704,10 +704,14 @@ abstract class Plugin extends Component implements TypesInterface
     {
         if ($this->isAttributeWriteable($event) && $this->onBeforeFind($event)) {
             if ($this->i18n) {
-                $event->sender->setAttribute(
-                    $this->name,
-                    I18n::decodeFindActive($event->sender->getAttribute($this->name), $this->i18nEmptyValue)
-                );
+
+                // get the new array value from an i18n json attribute
+                $value = I18n::decodeFindActive($event->sender->getAttribute($this->name), $this->i18nEmptyValue);
+                // set the new attribute value
+                $event->sender->setAttribute($this->name, $value);
+                // override the old attribute value in order to ensure this attribute is not marked as dirty
+                // see: 
+                $event->sender->setOldAttribute($this->name, $value);
             }
             
             $this->onAfterFind($event);


### PR DESCRIPTION
## Problem

When attributes are loaded from the database, the i18n attribute values will override existing json `{"de":"foobar"}` with an array `['de' => 'foobar']`. Therefore in the future lifecycle of the Active Record this attribute is dirty, which is not correct in terms of database value.

> The functions `load()` and `save()` will by default validate only the dirty attributes. This is what the rest UpdateAction does

The main problem with behavior we have encountered when we send a PUT request with a single attribute value like `{is_archived:1}` but then i18n attributes with an i18nrequiredattribute validator trys to validate the i18n attributes as they "have changed since loading" and are marked as dirty. Therefore the model can not be updated due to validation error `
`The given attribute \"title\" must be type of array.`

## Solution

In order to fix the problem we do:

1. Store the original database value in the new `setI18nOldValue()` method in order to have the option to access the original json values.
2. Override the old attribute value with the already new set value trough `setOldAttribute()` in the ngrest plugin method