### PR TITLE
add i18n required validator skip if unchanged

### DIFF
--- a/src/validators/I18nRequiredValidator.php
+++ b/src/validators/I18nRequiredValidator.php
@@ -5,6 +5,7 @@ namespace luya\admin\validators;
 use luya\admin\models\Lang;
 use luya\admin\Module;
 use luya\helpers\Json;
+use yii\db\BaseActiveRecord;
 use yii\validators\Validator;
 
 /**
@@ -47,10 +48,22 @@ class I18nRequiredValidator extends Validator
     public $emptyValueMessage = "i18n_required_validator_invalid_empty_value";
 
     /**
+     * @var boolean If enabled and the attribute value has not changed (not dirty) the validation will be skipped.
+     */
+    public $skipIfUnchanged = false;
+
+    /**
      * {@inheritDoc}
      */
     public function validateAttribute($model, $attribute)
     {
+        // if skip if unchanged is enabled and active record and the attribute has not changed, skip this validation rule.   
+        if ($this->skipIfUnchanged && $model instanceof BaseActiveRecord) {
+            if (!$model->isAttributeChanged($attribute)) {
+                return;
+            }
+        }
+        
         $array = $model->{$attribute};
 
         // As due to the ngrest plugin concept the value is already parsed from array to json.

--- a/tests/admin/validators/I18nRequiredValidatorTest.php
+++ b/tests/admin/validators/I18nRequiredValidatorTest.php
@@ -60,4 +60,22 @@ class I18nRequiredValidatorTest extends AdminModelTestCase
         $validator->validateAttribute($model, 'i18n');
         $this->assertSame('The value for language \"en\" can not be empty.', $model->getFirstError('i18n'));
     }
+
+    public function testSkipIfUnchanged()
+    {
+        $fixture = $this->createAdminLangFixture([
+            1 => [
+                'id' => 1,
+                'short_code' => 'en',
+                'is_deleted' => 0,
+            ]
+        ]);
+        
+        $model = $fixture->newModel;
+
+        $validator = new I18nRequiredValidator();
+        $validator->skipIfUnchanged = true;
+        $this->assertNull($validator->validateAttribute($model, 'short_code'));
+        $this->assertEmpty($model->getFirstError('i18n'));
+    }
 }


### PR DESCRIPTION
Add option to skip if unchanged, this can be required when performing put requests with just a single attribute.