### PR TITLE
unique email check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 3.7.1
 
-+ []() Fixed a bug where it was not possible to update the current admin user due to wrong unique email validation.
++ [#587](https://github.com/luyadev/luya-module-admin/pull/587) Fixed a bug where it was not possible to update the current admin user due to wrong unique email validation.
 
 ## 3.7.0 (26. October 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 3.7.1
+
++ []() Fixed a bug where it was not possible to update the current admin user due to wrong unique email validation.
+
 ## 3.7.0 (26. October 2020)
 
 > This release contains a behavior change where MysqlMutex is default instead of FileMutex. Check the [UPGRADE document](UPGRADE.md) to read more about breaking changes.

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -237,7 +237,7 @@ class User extends NgRestModel implements IdentityInterface, ChangePasswordInter
             [['email'], 'email'],
             [['email'], 'unique', 'except' => ['login']],
             [['email'], function ($attribute) {
-                if (self::find()->where(['email' => $this->$attribute])->exists()) {
+                if (self::find()->where(['email' => $this->$attribute, 'is_deleted' => true])->exists()) {
                     $this->addError($attribute, Module::t('user_model_email_deleted_account_exists'));
                 }
             }, 'except' => ['login']],


### PR DESCRIPTION
Fixed a bug where it was not possible to update the current admin user due to wrong unique email validation.