### PR TITLE
Add new command to clean old log entries, fixes issue #622

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.vscode
 composer.lock
 .phpunit.result.cache
+.php_cs.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 + [#609](https://github.com/luyadev/luya-module-admin/issues/609) Fixed generic issues when using PostgreSQL.
 + [#620](https://github.com/luyadev/luya-module-admin/pull/620) Changed echarts library to major [Version 5.0](https://github.com/apache/echarts/releases/tag/5.0.0)
 + [#603](https://github.com/luyadev/luya-module-admin/issues/603) Added option to disable the login form and display a maintenance message instead.
++ [#623](https://github.com/luyadev/luya-module-admin/pull/623) New command to cleanup ngrest log and cms log tables `./luya admin/log/cleanup app`.
 
 ## 3.9.0 (24. November 2020)
 

--- a/actions.phpunit.xml
+++ b/actions.phpunit.xml
@@ -15,7 +15,7 @@
         </testsuite>
     </testsuites>
     <filter>
-        <whitelist>
+        <whitelist processUncoveredFilesFromWhitelist="false">
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>

--- a/actions.phpunit.xml
+++ b/actions.phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+    backupGlobals="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
 >
     <testsuites>
         <testsuite name="LUYA TESTS">

--- a/src/commands/LogController.php
+++ b/src/commands/LogController.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace luya\admin\commands;
+
+use Yii;
+use luya\console\Command;
+
+/**
+ * LUYA Admin Log command.
+ *
+ * Cleanup ngrest and cms log data.
+ *
+ * @author
+ * @since
+ */
+class LogController extends Command
+{
+
+    /**
+     * @var boolean Whether to perform a dry run or not.
+     */
+    public $dryRun = false;
+
+    /**
+     * @var integer The minimum number of rows to keep.
+     */
+    public $rows = 5000;
+
+    /**
+     * @var integer The minimum age of log entries (in years) to keep.
+     */
+    public $years = 2;
+
+    /**
+     * @var array The list of log tables with timestamp field definition.
+     */
+    private $_dbLogTables = [
+        'admin_ngrest_log' => 'timestamp_create',
+        'cms_log' => 'timestamp',
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function options($actionID)
+    {
+        parent::options($actionID);
+        return ['logTable', 'dryRun', 'rows', 'years', 'interactive'];
+    }
+
+    /**
+     * Clean up logs older than a given threshold.
+     * @param the log tables to clean separated by comma
+     */
+    public function actionCleanup($logTableName)
+    {
+
+        // validate the minimum rows option
+        $this->rows  = (int)$this->rows;
+        if ($this->rows < 0){
+            return $this->outputError("Minimum rows to keep should be positive.");
+        }
+
+        // validate the years option
+        $this->years = (int)$this->years;
+        if ($this->years< 0){
+            return $this->outputError("Minimum Years to keep should be positive.");
+        }
+
+        // validate the log table names argument
+        if ( strtoupper($logTableName)=='ALL'){
+            $logTableList = array_keys($this->_dbLogTables);
+        }
+        else {
+            // extarct the table names and check them towards the known list of log tables
+            $logTableList = explode(',', $logTableName);
+            foreach ($logTableList as $name){
+                if (!isset($this->_dbLogTables[$name])){
+                    $this->outputInfo("Please specifiy a valid log table to clean among below list:");
+                    foreach ($this->_dbLogTables as $table=>$timestampField){
+                        $this->outputInfo("\t- $table");
+                    }
+                    return $this->outputError("Error. Invalid table name '$name'");
+                }
+            }
+        }
+
+        // clean old log entries for each log tbale provided
+        foreach ($logTableList as $logTableName){
+            // get the timestamp field form the tables definition
+            $timestampField = $this->_dbLogTables[$logTableName];
+
+            // output header
+            $this->outputInfo( sprintf("\nChecking log table %s", $logTableName ));
+            $this->outputInfo( str_repeat("-", 80) );
+
+            // check entries count towards minimum threshold
+            $totalRowsCount = Yii::$app->db->createCommand("SELECT count(*) as count FROM {{%$logTableName}}")->queryScalar();
+            $this->output(sprintf("Total entries found : $totalRowsCount (minimum to keep %s)",  $this->rows));
+            if ($totalRowsCount < $this->rows) {
+                $this->outputInfo("Log entries do not execeed minium to keep.");
+                continue;
+            }
+
+            //check entries age towards minimum years threshold
+            $referenceTimestamp = strtotime(sprintf("-%s year", $this->years));
+            $oldRowsCount = Yii::$app->db->createCommand("SELECT count(*) as count FROM {{%$logTableName}} WHERE $timestampField < :timestampLimit", [
+                ':timestampLimit' => $referenceTimestamp,
+            ])->queryScalar();
+
+            $this->output(sprintf("Total old entries : $oldRowsCount (reference date %s)",  date('d-M-Y H:i:s', $referenceTimestamp)));
+
+            if ($oldRowsCount == 0) {
+                $this->outputInfo("Log entries are  not old enough to delete.");
+                continue;
+            }
+
+            if ($this->interactive) {
+                if (!$this->confirm("Do you want to delete the extra entries from $logTableName table?")) {
+                    $this->outputError("Log entries clean-up aborted.");
+                    continue;
+                }
+            }
+
+            $removed = $this->dryRun? $oldRowsCount : Yii::$app->db->createCommand()->delete("{{%$logTableName}}", "$timestampField < :timestampLimit", [
+                ':timestampLimit' => $referenceTimestamp,
+            ])->execute();
+
+            if ($removed) {
+                $this->outputSuccess(sprintf("%s entries removed", $removed));
+            }
+            else {
+                $this->outputInfo("No log entries renoved.");
+            }
+        } // END foreach
+    } // END actionCleanup()
+} // END LogController class

--- a/src/commands/LogController.php
+++ b/src/commands/LogController.php
@@ -93,7 +93,7 @@ class LogController extends Command
     private function doClean($logTableName, $timestampField)
     {
         if ($this->moreThanMinimumRowsFound($logTableName) && $this->olderThanMiniumYearsFound($logTableName, $timestampField) && $this->removalConfirmed($logTableName)) {
-            $removed = $this->dryRun ?  $this->_oldRowsCount : Yii::$app->db->createCommand()->delete("{{%$logTableName}}", "$timestampField < :timestampLimit", [
+            $removed = $this->dryRun ? $this->_oldRowsCount : Yii::$app->db->createCommand()->delete("{{%$logTableName}}", "$timestampField < :timestampLimit", [
                 ':timestampLimit' => $this->_referenceTimestamp,
             ])->execute();
             if ($removed > 0) {
@@ -127,7 +127,7 @@ class LogController extends Command
      */
     private function validateRows()
     {
-        $this->rows  = (int)$this->rows;
+        $this->rows = (int) $this->rows;
         if ($this->rows < 0) {
             $this->outputError("Minimum rows to keep should be positive.");
             return false;

--- a/src/commands/LogController.php
+++ b/src/commands/LogController.php
@@ -40,6 +40,12 @@ class LogController extends Command
     ];
 
     /**
+     * Holds the minium timestamp to keep entries
+     * @var integer
+     */
+    private $_referenceTimestamp;
+
+    /**
      * @inheritdoc
      */
     public function options($actionID)
@@ -54,88 +60,108 @@ class LogController extends Command
      */
     public function actionCleanup($logTableName)
     {
+        if ( $this->_validateRows() && $this->_validateYears() && $this->_validateTables($logTableName)) {
+            // clean old log entries for each log tbale provided
+
+            $this->_referenceTimestamp = strtotime(sprintf("-%s year", $this->years));
+
+            foreach ($this->_dbLogTables as $logTableName=>$timestampField){
+                // output header
+                $this->outputInfo( sprintf("\nChecking log table %s", $logTableName ));
+                $this->outputInfo( str_repeat("-", 80) );
+                $this->_doClean($logTableName, $timestampField);
+            }
+        }
+    } // END actionCleanup()
+
+    private function _validateRows(){
         // validate the minimum rows option
         $this->rows  = (int)$this->rows;
         if ($this->rows < 0){
-            return $this->outputError("Minimum rows to keep should be positive.");
+            $this->outputError("Minimum rows to keep should be positive.");
+            return false;
         }
+        return true;
+    }
 
+    private function _validateYears(){
         // validate the years option
         $this->years = (int)$this->years;
         if ($this->years< 0){
-            return $this->outputError("Minimum Years to keep should be positive.");
+            $this->outputError("Minimum Years to keep should be positive.");
+            return false;
         }
+        return true;
+    }
 
+    private function _validateTables($logTableName){
         // validate the log table names argument
-        if ( strtoupper($logTableName)=='ALL'){
-            $logTableList = array_keys($this->_dbLogTables);
-        }
-        else {
+        if ( strtoupper($logTableName)!='ALL'){
             // extarct the table names and check them towards the known list of log tables
             $logTableList = explode(',', $logTableName);
-            foreach ($logTableList as $name){
-                if (!isset($this->_dbLogTables[$name])){
-                    $this->outputInfo("Please specifiy a valid log table to clean among below list:");
-                    foreach ($this->_dbLogTables as $table=>$timestampField){
-                        $this->outputInfo("\t- $table");
-                    }
-                    return $this->outputError("Error. Invalid table name '$name'");
-                }
+            $wrongTableNames = array_diff($logTableList, array_keys($this->_dbLogTables));
+            if ($wrongTableNames) {
+                $this->outputInfo("Please specifiy a valid log table to clean among below list:");
+                $this->outputInfo("  - " . join("\n  - ", array_keys($this->_dbLogTables)));
+                $this->outputError(sprintf("Error. Invalid table name '%s'", join("', '", $wrongTableNames) ));
+                return false;
+            }
+            else {
+                // keep oonly provided table names
+                $this->_dbLogTables = array_flip(array_intersect(array_flip($this->_dbLogTables), $logTableList));
             }
         }
+        return true;
+    }
 
-        // clean old log entries for each log tbale provided
-        foreach ($logTableList as $logTableName){
-            $this->_doClean($logTableName);
-        }        
-    } // END actionCleanup()
-    
-    private function _doClean($logTableName){
-        // get the timestamp field form the tables definition
-        $timestampField = $this->_dbLogTables[$logTableName];
+    private function _doClean($logTableName, $timestampField){
 
-        // output header
-        $this->outputInfo( sprintf("\nChecking log table %s", $logTableName ));
-        $this->outputInfo( str_repeat("-", 80) );
+        if ( $this->_checkEntriesCount($logTableName) && $oldRowsCount=$this->_checkEntriesAge($logTableName, $timestampField)) {
 
-        // check entries count towards minimum threshold
+            if ($this->interactive) {
+                if (!$this->confirm("Do you want to delete the extra entries from $logTableName table?")) {
+                    $this->outputError("Log entries clean-up aborted.");
+                    return;
+                }
+            }
+
+            $removed = $this->dryRun? $oldRowsCount : Yii::$app->db->createCommand()->delete("{{%$logTableName}}", "$timestampField < :timestampLimit", [
+                ':timestampLimit' => $this->_referenceTimestamp,
+            ])->execute();
+
+            if ($removed) {
+                $this->outputSuccess(sprintf("%s entries removed", $removed));
+            }
+            else {
+                $this->outputInfo("No log entries renoved.");
+            }
+        }
+    } // END _doClean()
+
+
+    private function _checkEntriesCount($logTableName){
+         // check entries count towards minimum threshold
         $totalRowsCount = Yii::$app->db->createCommand("SELECT count(*) as count FROM {{%$logTableName}}")->queryScalar();
         $this->output(sprintf("Total entries found : $totalRowsCount (minimum to keep %s)",  $this->rows));
         if ($totalRowsCount < $this->rows) {
             $this->outputInfo("Log entries do not execeed minium to keep.");
-            return;
+            return false;
         }
+        return true;
+    }
 
+    private function _checkEntriesAge($logTableName, $timestampField){
         //check entries age towards minimum years threshold
-        $referenceTimestamp = strtotime(sprintf("-%s year", $this->years));
         $oldRowsCount = Yii::$app->db->createCommand("SELECT count(*) as count FROM {{%$logTableName}} WHERE $timestampField < :timestampLimit", [
-            ':timestampLimit' => $referenceTimestamp,
+            ':timestampLimit' => $this->_referenceTimestamp,
         ])->queryScalar();
 
-        $this->output(sprintf("Total old entries : $oldRowsCount (reference date %s)",  date('d-M-Y H:i:s', $referenceTimestamp)));
+        $this->output(sprintf("Total old entries : $oldRowsCount (reference date %s)",  date('d-M-Y H:i:s', $this->_referenceTimestamp)));
 
         if ($oldRowsCount == 0) {
             $this->outputInfo("Log entries are  not old enough to delete.");
-            return;
         }
+        return $oldRowsCount;
+    }
 
-        if ($this->interactive) {
-            if (!$this->confirm("Do you want to delete the extra entries from $logTableName table?")) {
-                $this->outputError("Log entries clean-up aborted.");
-                return;
-            }
-        }
-
-        $removed = $this->dryRun? $oldRowsCount : Yii::$app->db->createCommand()->delete("{{%$logTableName}}", "$timestampField < :timestampLimit", [
-            ':timestampLimit' => $referenceTimestamp,
-        ])->execute();
-
-        if ($removed) {
-            $this->outputSuccess(sprintf("%s entries removed", $removed));
-        }
-        else {
-            $this->outputInfo("No log entries renoved.");
-        }
-    } // END _doClean()
-    
 } // END LogController class

--- a/src/commands/LogController.php
+++ b/src/commands/LogController.php
@@ -45,7 +45,7 @@ class LogController extends Command
      */
     private $_referenceTimestamp;
     /**
-     * Holds the old entries number found during age check 
+     * Holds the old entries number found during age check
      * @var integer
      */
     private $_oldRowsCount;
@@ -65,73 +65,76 @@ class LogController extends Command
      */
     public function actionCleanup($logTableName)
     {
-        if ( $this->_validateRows() && $this->_validateYears() && $this->_validateTables($logTableName)) {
+        if ($this->_validateRows() && $this->_validateYears() && $this->_validateTables($logTableName)) {
             // clean old log entries for each log tbale provided
             $this->_referenceTimestamp = strtotime(sprintf("-%s year", $this->years));
-            foreach ($this->_dbLogTables as $logTableName=>$timestampField){
+            foreach ($this->_dbLogTables as $logTableName=>$timestampField) {
                 // output header
-                $this->outputInfo( sprintf("\nChecking log table %s", $logTableName ));
-                $this->outputInfo( str_repeat("-", 80) );                
+                $this->outputInfo(sprintf("\nChecking log table %s", $logTableName));
+                $this->outputInfo(str_repeat("-", 80));
                 $this->_doClean($logTableName, $timestampField);
             }
         }
     } // END actionCleanup()
 
-    private function _doClean($logTableName, $timestampField){
-        if ( $this->_moreThanMinimumRowsFound($logTableName) && $this->_olderThanMiniumYearsFound($logTableName, $timestampField) && $this->_removalConfirmed($logTableName)) {
+    private function _doClean($logTableName, $timestampField)
+    {
+        if ($this->_moreThanMinimumRowsFound($logTableName) && $this->_olderThanMiniumYearsFound($logTableName, $timestampField) && $this->_removalConfirmed($logTableName)) {
             $removed = $this->dryRun ?  $this->_oldRowsCount : Yii::$app->db->createCommand()->delete("{{%$logTableName}}", "$timestampField < :timestampLimit", [
                 ':timestampLimit' => $this->_referenceTimestamp,
             ])->execute();
             if ($removed > 0) {
-               $this->outputSuccess(sprintf("%s entries removed", $removed));
-            }
-            else {
-               $this->outputInfo("No log entries renoved.");
+                $this->outputSuccess(sprintf("%s entries removed", $removed));
+            } else {
+                $this->outputInfo("No log entries renoved.");
             }
         }
     } // END _doClean()
 
-    private function _removalConfirmed($logTableName){
+    private function _removalConfirmed($logTableName)
+    {
         if ($this->interactive && !$this->confirm("Do you want to delete the extra entries from $logTableName table?")) {
             $this->outputError("Log entries clean-up aborted.");
             return false;
-        } 
+        }
         return true;
     }
     
-    private function _validateRows(){
+    private function _validateRows()
+    {
         // validate the minimum rows option
         $this->rows  = (int)$this->rows;
-        if ($this->rows < 0){
+        if ($this->rows < 0) {
             $this->outputError("Minimum rows to keep should be positive.");
             return false;
         }
         return true;
     }
 
-    private function _validateYears(){
+    private function _validateYears()
+    {
         // validate the years option
         $this->years = (int)$this->years;
-        if ($this->years< 0){
+        if ($this->years< 0) {
             $this->outputError("Minimum Years to keep should be positive.");
             return false;
         }
         return true;
     }
 
-    private function _validateTables($logTableName){
+    private function _validateTables($logTableName)
+    {
         // validate the log table names argument
-        if ( strtoupper($logTableName)!='ALL'){
+        if (strtoupper($logTableName)!='ALL') {
             // extarct the table names and check them towards the known list of log tables
             $logTableList = explode(',', $logTableName);
             $wrongTableNames = array_diff($logTableList, array_keys($this->_dbLogTables));
             if ($wrongTableNames) {
                 $this->outputInfo("Please specifiy a valid log table to clean among below list:");
                 $this->outputInfo("  - " . join("\n  - ", array_keys($this->_dbLogTables)));
-                $this->outputError(sprintf("Error. Invalid table name '%s'", join("', '", $wrongTableNames) ));
+                $this->outputError(sprintf("Error. Invalid table name '%s'", join("', '", $wrongTableNames)));
                 return false;
-            }
-            else {
+            } else {
                 // keep oonly provided table names
                 $this->_dbLogTables = array_flip(array_intersect(array_flip($this->_dbLogTables), $logTableList));
             }
@@ -139,10 +142,11 @@ class LogController extends Command
         return true;
     }
 
-    private function _moreThanMinimumRowsFound($logTableName){
-         // check entries count towards minimum threshold
+    private function _moreThanMinimumRowsFound($logTableName)
+    {
+        // check entries count towards minimum threshold
         $totalRowsCount = Yii::$app->db->createCommand("SELECT count(*) as count FROM {{%$logTableName}}")->queryScalar();
-        $this->output(sprintf("Total entries found : $totalRowsCount (minimum to keep %s)",  $this->rows));
+        $this->output(sprintf("Total entries found : $totalRowsCount (minimum to keep %s)", $this->rows));
         if ($totalRowsCount < $this->rows) {
             $this->outputInfo("Log entries do not execeed minium to keep.");
             return false;
@@ -150,13 +154,14 @@ class LogController extends Command
         return true;
     }
 
-    private function _olderThanMiniumYearsFound($logTableName, $timestampField){
+    private function _olderThanMiniumYearsFound($logTableName, $timestampField)
+    {
         //check entries age towards minimum years threshold
         $this->_oldRowsCount = Yii::$app->db->createCommand("SELECT count(*) as count FROM {{%$logTableName}} WHERE $timestampField < :timestampLimit", [
             ':timestampLimit' => $this->_referenceTimestamp,
         ])->queryScalar();
 
-        $this->output(sprintf("Total old entries : $this->_oldRowsCount (reference date %s)",  date('d-M-Y H:i:s', $this->_referenceTimestamp)));
+        $this->output(sprintf("Total old entries : $this->_oldRowsCount (reference date %s)", date('d-M-Y H:i:s', $this->_referenceTimestamp)));
 
         if ($this->_oldRowsCount == 0) {
             $this->outputInfo("Log entries are  not old enough to delete.");
@@ -164,5 +169,4 @@ class LogController extends Command
         }
         return true;
     }
-
 } // END LogController class

--- a/tests/admin/commands/LogControllerTest.php
+++ b/tests/admin/commands/LogControllerTest.php
@@ -33,4 +33,13 @@ class LogControllerTest extends AdminConsoleSqLiteTestCase
         $ctrl->years = -1;
         $this->assertFalse($this->invokeMethod($ctrl, 'validateYears'));
     }
+    
+    public function testValidateRows()
+    {
+        $ctrl = $this->createCommand();
+        $this->assertTrue($this->invokeMethod($ctrl, 'validateRows'));
+        $ctrl->rows = -1;
+        $this->assertFalse($this->invokeMethod($ctrl, 'validateRows'));
+    }
+
 }

--- a/tests/admin/commands/LogControllerTest.php
+++ b/tests/admin/commands/LogControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace admintests\admin\commands;
+
+use admintests\AdminConsoleSqLiteTestCase;
+use luya\admin\commands\LogController;
+
+class LogControllerTest extends AdminConsoleSqLiteTestCase
+{
+    /**
+     * @return LogController
+     */
+    private function createCommand()
+    {
+        return new LogController('log', $this->app);
+    }
+
+    public function testTables()
+    {
+        $ctrl = $this->createCommand();
+
+        $this->assertFalse($this->invokeMethod($ctrl, 'validateTables', ['foo']));
+        $this->assertFalse($this->invokeMethod($ctrl, 'validateTables', [null]));
+        $this->assertTrue($this->invokeMethod($ctrl, 'validateTables', ['all']));
+        $this->assertFalse($this->invokeMethod($ctrl, 'validateTables', ['cms_log,butthisiswrong']));
+        $this->assertTrue($this->invokeMethod($ctrl, 'validateTables', ['admin_ngrest_log,cms_log']));
+    }
+
+    public function testValidateYear()
+    {
+        $ctrl = $this->createCommand();
+        $this->assertTrue($this->invokeMethod($ctrl, 'validateYears'));
+        $ctrl->years = -1;
+        $this->assertFalse($this->invokeMethod($ctrl, 'validateYears'));
+    }
+}


### PR DESCRIPTION
### What are you changing/introducing
Adding new console command implementing the log cleaning feature
This new command will do it (via a cron job on a monthly bases for instance) where it will delete log files older than YYY years but only if we have more more then XXX rows. This ensures log files won’t be deleted if there just a few log entries.

### What is the reason for changing/introducing
Overtime log tables such as admin_ngrest_log and cms_log will contain large amount of data. To keep the database cleaner and if we don not need these logs anymore we have to manually perform a cleanup.

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | n/a
| Fixed issues  | 622
