### PR TITLE
Fixed typo in folders directory service name

### DIFF
--- a/src/resources/js/directives.js
+++ b/src/resources/js/directives.js
@@ -3114,8 +3114,8 @@ zaa.directive("storageFileManager", function () {
             onlyImages: '@onlyImages'
         },
         controller: [
-            '$scope', '$http', '$filter', '$timeout', '$q', 'HtmlStorage', 'cfpLoadingBar', 'Upload', 'ServiceFoldersData', 'ServiceFilesData', 'LuyaLoading', 'AdminToastService', 'ServiceFoldersDirecotryId', 'ServiceAdminTags', 'ServiceQueueWaiting',
-            function ($scope, $http, $filter, $timeout, $q, HtmlStorage, cfpLoadingBar, Upload, ServiceFoldersData, ServiceFilesData, LuyaLoading, AdminToastService, ServiceFoldersDirecotryId, ServiceAdminTags, ServiceQueueWaiting) {
+            '$scope', '$http', '$filter', '$timeout', '$q', 'HtmlStorage', 'cfpLoadingBar', 'Upload', 'ServiceFoldersData', 'ServiceFilesData', 'LuyaLoading', 'AdminToastService', 'ServiceFoldersDirectoryId', 'ServiceAdminTags', 'ServiceQueueWaiting',
+            function ($scope, $http, $filter, $timeout, $q, HtmlStorage, cfpLoadingBar, Upload, ServiceFoldersData, ServiceFilesData, LuyaLoading, AdminToastService, ServiceFoldersDirectoryId, ServiceAdminTags, ServiceQueueWaiting) {
 
                 // ServiceFoldersData inheritance
 
@@ -3222,10 +3222,10 @@ zaa.directive("storageFileManager", function () {
 
                 // ServiceFolderId
 
-                $scope.currentFolderId = ServiceFoldersDirecotryId.folderId;
+                $scope.currentFolderId = ServiceFoldersDirectoryId.folderId;
 
-                $scope.foldersDirecotryIdReload = function () {
-                    return ServiceFoldersDirecotryId.load(true);
+                $scope.foldersDirectoryIdReload = function () {
+                    return ServiceFoldersDirectoryId.load(true);
                 }
 
                 // file replace logic
@@ -3446,7 +3446,7 @@ zaa.directive("storageFileManager", function () {
                     $scope.currentPageId = 1;
                     $scope.selectedFiles = [];
                     if (noState !== true && oldCurrentFolder != folderId) {
-                        ServiceFoldersDirecotryId.folderId = folderId;
+                        ServiceFoldersDirectoryId.folderId = folderId;
                         $http.post('admin/api-admin-common/save-filemanager-folder-state', { folderId: folderId }, { ignoreLoadingBar: true });
                     }
                 };

--- a/src/resources/js/services.js
+++ b/src/resources/js/services.js
@@ -1,11 +1,11 @@
 // service resolver
-adminServiceResolver = ['ServiceFoldersData', 'ServiceFiltersData', 'ServiceLanguagesData', 'ServicePropertiesData', 'AdminLangService', 'ServiceFoldersDirecotryId', function(ServiceFoldersData, ServiceFiltersData, ServiceLanguagesData, ServicePropertiesData, AdminLangService, ServiceFoldersDirecotryId) {
+adminServiceResolver = ['ServiceFoldersData', 'ServiceFiltersData', 'ServiceLanguagesData', 'ServicePropertiesData', 'AdminLangService', 'ServiceFoldersDirectoryId', function(ServiceFoldersData, ServiceFiltersData, ServiceLanguagesData, ServicePropertiesData, AdminLangService, ServiceFoldersDirectoryId) {
 	ServiceFiltersData.load();
 	ServiceFoldersData.load();
 	ServiceLanguagesData.load();
 	ServicePropertiesData.load();
 	AdminLangService.load();
-	ServiceFoldersDirecotryId.load();
+	ServiceFoldersDirectoryId.load();
 }];
 
 /**
@@ -158,18 +158,18 @@ zaa.factory("ServiceFoldersData", ['$http', '$q', '$rootScope', function($http, 
 
 /*
 
-$scope.folderId = ServiceFoldersDirecotryId.folderId;
+$scope.folderId = ServiceFoldersDirectoryId.folderId;
 					
 $scope.$on('service:FoldersDirectoryId', function(event, folderId) {
 	$scope.folderId = folderId;
 });
 
-$scope.foldersDirecotryIdReload = function() {
-	return ServiceFoldersDirecotryId.load(true);
+$scope.foldersDirectoryIdReload = function() {
+	return ServiceFoldersDirectoryId.load(true);
 }
 
 */
-zaa.factory("ServiceFoldersDirecotryId", ['$http', '$q', '$rootScope', function($http, $q, $rootScope) {
+zaa.factory("ServiceFoldersDirectoryId", ['$http', '$q', '$rootScope', function($http, $q, $rootScope) {
 	
 	var service = [];
 	


### PR DESCRIPTION
`ServiceFoldersDirecotryId` --> `ServiceFoldersDirectoryId`
`foldersDirecotryIdReload` --> `foldersDirectoryIdReload`