### PR TITLE
add exception if file not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 + [#665](https://github.com/luyadev/luya-module-admin/pull/665) Replaced `<span>` tags with `<a>` tags in main admin menu and submenus.
 + [#663](https://github.com/luyadev/luya-module-admin/issues/663) A new `TagRelation::cleanup(ActiveRecord $model)` method to remove all tag relations for a certain model. 
 + [#481](https://github.com/luyadev/luya-module-admin/issues/481) Fixed issue where file manager files count is not updated accordingly after uploading new files.
++ [#]() Throw an exception when the image can not find the requested file.
 
 ## 4.1.0 (21. September 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 + [#665](https://github.com/luyadev/luya-module-admin/pull/665) Replaced `<span>` tags with `<a>` tags in main admin menu and submenus.
 + [#663](https://github.com/luyadev/luya-module-admin/issues/663) A new `TagRelation::cleanup(ActiveRecord $model)` method to remove all tag relations for a certain model. 
 + [#481](https://github.com/luyadev/luya-module-admin/issues/481) Fixed issue where file manager files count is not updated accordingly after uploading new files.
-+ [#]() Throw an exception when the image can not find the requested file.
++ [#674](https://github.com/luyadev/luya-module-admin/pull/674) Throw an exception when the image can not find the requested file.
 
 ## 4.1.0 (21. September 2021)
 

--- a/src/image/Item.php
+++ b/src/image/Item.php
@@ -4,6 +4,7 @@ namespace luya\admin\image;
 
 use Yii;
 use luya\admin\storage\ItemAbstract;
+use luya\Exception;
 
 /**
  * Image Item Detail Object.
@@ -199,6 +200,10 @@ class Item extends ItemAbstract
     {
         if ($this->_file === null) {
             $this->_file = Yii::$app->storage->getFile($this->getFileId());
+
+            if (!$this->_file) {
+                throw new Exception("The file \"$this->getFileId()\" does not exists in the storage system.");
+            }
         }
         
         return $this->_file;


### PR DESCRIPTION
Throw an exception when the image can not find the requested file. This can be the case when an image is download in proxy sync but the file does not exist.