### PR TITLE
Fixed placeholders within zaaMultipleInputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 4.2.0
 
++ [#695](https://github.com/luyadev/luya-module-admin/pull/695) Fixed placeholders within `zaaMultipleInputs`.
 + [#694](https://github.com/luyadev/luya-module-admin/pull/694) Fixed CRUD title involving NgRestPools.
 + [#690](https://github.com/luyadev/luya-module-admin/pull/690) Option to pass additional variables to the dashboard objects.
 + [#676](https://github.com/luyadev/luya-module-admin/issues/676) Fixed hidden NgRest attributes issue in the group-by-field select.

--- a/src/resources/js/formdirectives.js
+++ b/src/resources/js/formdirectives.js
@@ -2884,7 +2884,7 @@ zaa.directive("zaaMultipleInputs", function () {
                             '<p class="alert alert-info" ng-hide="model.length > 0">' + i18n['js_dir_no_selection'] + '</p>' +
                             '<div ng-repeat="(msortKey,row) in model track by msortKey" class="list-item" ng-init="ensureRow(row)">' +
                                 '<div ng-repeat="(mutliOptKey,opt) in options track by mutliOptKey">' +
-                                    '<zaa-injector dir="opt.type" options="opt.options" fieldid="id-{{msortKey}}-{{mutliOptKey}}" initvalue="{{opt.initvalue}}" label="{{opt.label}}" model="row[opt.var]"></zaa-injector>' +
+                                    '<zaa-injector dir="opt.type" options="opt.options" fieldid="id-{{msortKey}}-{{mutliOptKey}}" placeholder="{{opt.placeholder}}" initvalue="{{opt.initvalue}}" label="{{opt.label}}" model="row[opt.var]"></zaa-injector>' +
                                 '</div>' +
                                 '<div class="list-buttons">' +
                                     '<div class="btn-group" role="group">' +


### PR DESCRIPTION
### What are you changing/introducing

Added missing `placeholder` attribute to `<zaa-injector>` in template of `zaaMultipleInputs` directive.

### What is the reason for changing/introducing

Input placeholders are missing within `zaaMultipleInputs` resp. `TYPE_MULTIPLE_INPUTS`.

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
