### PR TITLE
Fixed reversed order of modules in admin menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 4.2.0
 
+> This release changes the admin menu order. Check the [UPGRADE document](UPGRADE.md) to read more about breaking changes.
+
++ [#698](https://github.com/luyadev/luya-module-admin/pull/698) Fixed reversed order of modules in admin menu.
 + [#695](https://github.com/luyadev/luya-module-admin/pull/695) Fixed placeholders within `zaaMultipleInputs`.
 + [#694](https://github.com/luyadev/luya-module-admin/pull/694) Fixed CRUD title involving NgRestPools.
 + [#690](https://github.com/luyadev/luya-module-admin/pull/690) Option to pass additional variables to the dashboard objects.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@ This document will help you upgrading from a LUYA admin module version into anot
 
 ## from 4.1 to 4.2
 
-+ Invers the `modules` order in your config file (e.g. `config.php`) to preserve the old admin menu order.
++ Invert the `modules` order in your config file (e.g. `config.php`) to preserve the old admin menu order.
 
 from:
 ```php

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,28 @@
 
 This document will help you upgrading from a LUYA admin module version into another. For more detailed informations about the breaking changes **click the issue detail link**, there you can examples of how to change your code.
 
-## from 3.x t 4.0
+## from 4.1 to 4.2
+
++ Invers the `modules` order in your config file (e.g. `config.php`) to preserve the old admin menu order.
+
+from:
+```php
+'modules' => [
+   /*...*/, // bottommost module in admin menu
+   'admin' => [ /*...*/ ],
+   'cmsadmin' => [ /*...*/ ], // topmost module in admin menu
+],
+```
+to:
+```php
+'modules' => [
+   'cmsadmin' => [ /*...*/ ], // topmost module in admin menu
+   'admin' => [ /*...*/ ],
+   /*...*/, // bottommost module in admin menu
+],
+```
+
+## from 3.x to 4.0
 
 + Run the migrate command, as new migrations are available.
 + Admin 4.0 requires luya core 2.0, which is part of the new minimum requirement.

--- a/src/components/AdminMenu.php
+++ b/src/components/AdminMenu.php
@@ -109,7 +109,7 @@ class AdminMenu extends \yii\base\Component
             }
             // call the interface menu method returns the array for the given Module.
             $data = $menuBuilder->menu();
-            $menu = ArrayHelper::merge($data, $menu);
+            $menu = ArrayHelper::merge($menu, $data);
         }
         
         $this->_menu = $menu;


### PR DESCRIPTION
### What are you changing/introducing

Inverted the modules order in admin menu.

### What is the reason for changing/introducing

Modules are in reversed order in admin menu.
This is irritating since the order of the modules own menu items generated by `AdminMenuBuilder` is not reversed.

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | Closes #691.
