### PR TITLE
Added an exception to AdminLanguage component + typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 4.8.0
 
-+ [#739](https://github.com/luyadev/luya-module-admin/pull/739) Added option to disabled the multiple input type controls (add, remove and sort).
++ [#740](https://github.com/luyadev/luya-module-admin/pull/740) AdminLanguage component will throw an Exception if no default language is found.
++ [#739](https://github.com/luyadev/luya-module-admin/pull/739) Added option to disable the multiple input type controls (add, remove and sort).
 
 ## 4.7.2 (26. October 2022)
 

--- a/src/components/AdminLanguage.php
+++ b/src/components/AdminLanguage.php
@@ -3,6 +3,7 @@
 namespace luya\admin\components;
 
 use luya\admin\models\Lang;
+use luya\Exception;
 use luya\helpers\ArrayHelper;
 use luya\traits\CacheableTrait;
 use Yii;
@@ -51,7 +52,7 @@ class AdminLanguage extends Component
     private $_activeLanguage;
 
     /**
-     * Get the array of the current active language (its not an AR object!)
+     * Get the array of the current active language (it's not an AR object!)
      *
      * Determines active language by:
      *
@@ -59,6 +60,7 @@ class AdminLanguage extends Component
      * 2. language which has is_default flag enabled.
      *
      * @return array
+     * @throws Exception
      */
     public function getActiveLanguage()
     {
@@ -78,6 +80,12 @@ class AdminLanguage extends Component
             if (empty($this->_activeLanguage)) {
                 $this->_activeLanguage = ArrayHelper::searchColumn($this->getLanguages(), 'is_default', 1);
             }
+
+            // if _activeLanguage is still empty, then the system does not have a default language
+            if (empty($this->_activeLanguage)) {
+                throw new Exception("The system must have a default language set.");
+            }
+
         }
 
         return $this->_activeLanguage;

--- a/src/helpers/Storage.php
+++ b/src/helpers/Storage.php
@@ -128,7 +128,7 @@ class Storage
             $width = (int)$dimensions[0];
             $height = (int)$dimensions[1];
         } elseif ($throwException) {
-            throw new Exception("Unable to determine the resoltuions of the file $filePath.");
+            throw new Exception("Unable to determine the resolutions of the file $filePath.");
         }
 
         return [


### PR DESCRIPTION
### What are you changing/introducing
AdminLanguage component will fire an exception when no default language can be found.


### What is the reason for changing/introducing
When no default language set in the system an expressions like `$this->getDefaultLanguage()['short_code']` will produce errors since `$this->getDefaultLanguage()` is false.

An exception will give a more meaningful error message.


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
