### PR TITLE
Provided popup delay for tooltip directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.0.2
 
-+ [#755](https://github.com/luyadev/luya-module-admin/pull/755) Provided popup delay for tooltip directive.
++ [#755](https://github.com/luyadev/luya-module-admin/pull/755) Provided popup delay `tooltip-popup-delay` for tooltip directive.
 + [#754](https://github.com/luyadev/luya-module-admin/pull/754) Improved setup outputs.
 
 ## 5.0.1 (7. February 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.0.2
 
++ [#755](https://github.com/luyadev/luya-module-admin/pull/755) Provided popup delay for tooltip directive.
 + [#754](https://github.com/luyadev/luya-module-admin/pull/754) Improved setup outputs.
 
 ## 5.0.1 (7. February 2024)


### PR DESCRIPTION
### What are you changing/introducing

- Added attribute `tooltip-popup-delay` to tooltip directive (like in Bootstrap or AngularUI)
  - use of [$timeout](https://docs.angularjs.org/api/ng/service/$timeout)
  - cancel timeout on `mouseleave` or when tooltip is destroyed, so it don't get into conflict with other tooltips
- Example: `<span tooltip tooltip-text="Tooltip" tooltip-popup-delay="500">...</span>`


### What is the reason for changing/introducing

- Ability to show tooltips with a delay, not only instantly


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | &ndash;
