### PR TITLE
Fixed collapsing tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.0.2
 
-+ [#756](https://github.com/luyadev/luya-module-admin/pull/756) Fixed collapsing tooltips.
++ [#756](https://github.com/luyadev/luya-module-admin/pull/756) Fixed collapsing tooltips due empty content in this case the tooltip is no longer displayed
 + [#755](https://github.com/luyadev/luya-module-admin/pull/755) Provided popup delay `tooltip-popup-delay` for tooltip directive.
-+ [#754](https://github.com/luyadev/luya-module-admin/pull/754) Improved setup outputs.
++ [#754](https://github.com/luyadev/luya-module-admin/pull/754) Improved `admin/setup` command outputs.
 
 ## 5.0.1 (7. February 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.0.2
 
++ [#756](https://github.com/luyadev/luya-module-admin/pull/756) Fixed collapsing tooltips.
 + [#755](https://github.com/luyadev/luya-module-admin/pull/755) Provided popup delay `tooltip-popup-delay` for tooltip directive.
 + [#754](https://github.com/luyadev/luya-module-admin/pull/754) Improved setup outputs.
 

--- a/src/resources/js/directives.js
+++ b/src/resources/js/directives.js
@@ -135,12 +135,13 @@ zaa.directive("linkObjectToString", function () {
  * ```
  *
  *
- * You can provide an Image URL beside or instead of text.
+ * In order to trigger an expression call instead of a static text use:
  *
  * ```html
- * <span tooltip tooltip-image-url="http://image.url">...</span>
+ * <span tooltip tooltip-expression="scopeFunction(fooBar)">Span Text</span>
  * ```
- *
+ * 
+ * 
  * Change the position (`top`, `right`, `bottom` or `left`):
  *
  * ```html
@@ -155,20 +156,20 @@ zaa.directive("linkObjectToString", function () {
  * ```
  *
  *
- * In order to trigger an expression call instead of a static text use:
- *
- * ```html
- * <span tooltip tooltip-expression="scopeFunction(fooBar)">Span Text</span>
- * ```
- *
- *
  * Display a tooltip with delay in milliseconds:
  *
  * ```html
  * <span tooltip tooltip-text="Tooltip" tooltip-popup-delay="500">...</span>
  * ```
+ * 
+ * 
+ * You can provide an Image URL beside or instead of text.
  *
- *
+ * ```html
+ * <span tooltip tooltip-image-url="http://image.url">...</span>
+ * ```
+ * 
+ * 
  * Disable tooltip based on variable (two way binding):
  *
  * ```html
@@ -262,8 +263,10 @@ zaa.directive("tooltip", ['$document', '$http', '$timeout', function ($document,
                 }
 
                 // Generate tooltip HTML for the first time
-                if ((!scope.pop || lastValue != scope.tooltipText) && (typeof scope.tooltipDisabled === 'undefined' || scope.tooltipDisabled === false)) {
-                    
+                if ( (!scope.pop || lastValue != scope.tooltipText)
+                  && (typeof scope.tooltipDisabled === 'undefined' || scope.tooltipDisabled === false)
+                  && (scope.tooltipText || scope.tooltipImageUrl || scope.tooltipPreviewUrl) ) {
+
                     lastValue = scope.tooltipText
 
                     var html = '<div class="tooltip tooltip-' + (scope.tooltipPosition || defaultPosition) + (scope.tooltipImageUrl ? ' tooltip-image' : '') + '" role="tooltip">' +


### PR DESCRIPTION
### What are you changing/introducing

- Fixed collapsing tooltips due empty content
  - in this case the tooltip is no longer displayed

### What is the reason for changing/introducing

- If neigther `tooltip-text`, nor `tooltip-expression`, nor `tooltip-image-url`, nor `tooltip-preview-url` is set the tooltip is displayed but collapsed:
 ![CollapsingTooltip](https://github.com/luyadev/luya-module-admin/assets/6715827/cc45c827-914b-4997-9fe1-2d55d3c00e98)



### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | &ndash;